### PR TITLE
FMU execution sequencing

### DIFF
--- a/aerosim-core/src/math/mod.rs
+++ b/aerosim-core/src/math/mod.rs
@@ -5,3 +5,8 @@ pub use rotator::Rotator;
 
 pub mod vector;
 pub use vector::Vector3;
+
+pub fn round_to_decimal_places(value: f64, decimal_places: u32) -> f64 {
+    let multiplier = 10.0_f64.powi(decimal_places as i32);
+    (value * multiplier).round() / multiplier
+}

--- a/aerosim-data/src/types/timestamp.rs
+++ b/aerosim-data/src/types/timestamp.rs
@@ -50,6 +50,12 @@ impl TimeStamp {
         self.sec as f64 + self.nanosec as f64 * 1e-9
     }
 
+    pub fn to_sec_rounded(&self, round_num_digits: u32) -> f64 {
+        let raw_sec: f64 = self.to_sec();
+        let multiplier = 10.0_f64.powi(round_num_digits as i32);
+        (raw_sec * multiplier).round() / multiplier
+    }
+
     #[staticmethod]
     pub fn from_millis(millisec: u64) -> Self {
         let dur = Duration::from_millis(millisec);

--- a/aerosim-world/python/aerosim_world/pyfmu_driver.py
+++ b/aerosim-world/python/aerosim_world/pyfmu_driver.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import threading
+import math
 
 from dotty_dictionary import dotty
 
@@ -15,10 +16,14 @@ from aerosim_sensors import adsb_functions
 
 
 class PyFmuDriver:
-    def __init__(self, fmu_id: str, working_dir: str = "", middleware_type = "zenoh") -> None:
+    def __init__(
+        self, fmu_id: str, working_dir: str = "", middleware_type="zenoh"
+    ) -> None:
         self.fmu_id = fmu_id
+        self.fmudriver_name = f"[aerosim.fmudriver.{self.fmu_id}]"
         self.working_dir = working_dir
         self.unzipped_temp_dir = None
+        self.num_time_decimals = 6  # round time to microsec decimal place
         self.fmu_config_json = {}
         self.aerosim_root_path = os.getenv("AEROSIM_ROOT")
 
@@ -37,9 +42,7 @@ class PyFmuDriver:
             "aerosim.orchestrator.commands",
             self.orchestator_commands_callback,
         )
-        self.transport.subscribe(
-            aerosim_types.JsonData, "aerosim.clock", self.clock_callback
-        )
+        print(f"{self.fmudriver_name} Subscribed to 'aerosim.orchestrator.commands'")
 
         self.reset_data()
 
@@ -61,12 +64,13 @@ class PyFmuDriver:
     def reset_data(self):
         # FMU model data
         self.fmu_filename = ""
-        self.fmudriver_name = f"[aerosim.fmudriver.{self.fmu_id}]"
         self.model_description = None
+
         self.fmu_var_refs = {}
         self.fmu_var_types = {}
         self.fmu_var_causality = {}
         self.fmu_var_dims = {}
+
         self.fmu_instance: FMU3Slave | FMU2Slave | None = None
 
         # FMU instance data
@@ -86,7 +90,7 @@ class PyFmuDriver:
         # Track a set of which topics are aux outputs that need variable remapping
         self.aux_topics_to_publish = set()
 
-    def load_config(self):
+    def load_config(self) -> tuple[str, str]:
         self.all_topics_to_subscribe.clear()
         self.aux_topics_to_subscribe.clear()
         self.aux_topics_to_publish.clear()
@@ -119,6 +123,21 @@ class PyFmuDriver:
                 self.out_topic_data[out_topic_root] = {}
             # print(f"topics_to_publish = {self.topics_to_publish}")
 
+        # Parse step_trigger_topic
+        if "step_trigger_topic" in self.fmu_config_json:
+            step_trigger_topic = self.fmu_config_json["step_trigger_topic"]["topic"]
+            step_trigger_msg_type = self.fmu_config_json["step_trigger_topic"][
+                "msg_type"
+            ]
+        else:
+            print(
+                f"{self.fmudriver_name} Unable to find 'step_trigger_topic' field in FMU config. Using base 'aerosim.clock' topic as step trigger."
+            )
+            step_trigger_topic = "aerosim.clock"
+            step_trigger_msg_type = "aerosim::types::JsonData"
+
+        return (step_trigger_topic, step_trigger_msg_type)
+
     def load_fmu(self):
         fmu_model_path = self.fmu_config_json["fmu_model_path"]
         if not os.path.isfile(fmu_model_path) and self.aerosim_root_path is not None:
@@ -138,18 +157,20 @@ class PyFmuDriver:
 
         # Collect the value references
         for var in self.model_description.modelVariables:
+            print(
+                f"{self.fmudriver_name} "
+                f"FMU ref={var.valueReference} "
+                f"var='{var.name}', "
+                f"type={var.type}, "
+                f"dims={[dim.start for dim in var.dimensions]}, "
+                f"causality={var.causality}"
+            )
             self.fmu_var_refs[var.name] = var.valueReference
             self.fmu_var_types[var.name] = var.type
             self.fmu_var_dims[var.name] = [dim.start for dim in var.dimensions]
             self.fmu_var_causality[var.name] = var.causality
-            print(
-                f"{self.fmudriver_name} "
-                f"FMU ref={self.fmu_var_refs[var.name]} "
-                f"var='{var.name}', "
-                f"type={self.fmu_var_types[var.name]}, "
-                f"dims={self.fmu_var_dims[var.name]}, "
-                f"causality={self.fmu_var_causality[var.name]}"
-            )
+
+        print(f"{self.fmudriver_name} Loaded {len(self.fmu_var_refs)} variables.")
 
         # Extract the FMU
         self.unzipped_temp_dir = fmpy.extract(
@@ -179,7 +200,7 @@ class PyFmuDriver:
             return
 
     def set_fmu_float(self, fmu_var: str, value: float | list[float]):
-        if type(value) is float:
+        if type(value) is not list:
             value = [value]
         if self.model_description.fmiVersion == "3.0":
             self.fmu_instance.setFloat64([self.fmu_var_refs[fmu_var]], value)
@@ -207,7 +228,7 @@ class PyFmuDriver:
         return out_vals
 
     def set_fmu_int(self, fmu_var: str, value: int | list[int]):
-        if type(value) is int:
+        if type(value) is not list:
             value = [value]
         if self.model_description.fmiVersion == "3.0":
             self.fmu_instance.setInt64([self.fmu_var_refs[fmu_var]], value)
@@ -225,7 +246,6 @@ class PyFmuDriver:
             )
             if not array_dim:
                 out_vals = out_vals[0]
-
         elif self.model_description.fmiVersion == "2.0":
             if array_dim:
                 print("FMU 2.0 does not support array dimensions, ignoring array_dim.")
@@ -236,7 +256,7 @@ class PyFmuDriver:
         return out_vals
 
     def set_fmu_string(self, fmu_var: str, value: str | list[str]):
-        if type(value) is str:
+        if type(value) is not list:
             value = [value]
         self.fmu_instance.setString([self.fmu_var_refs[fmu_var]], value)
 
@@ -249,7 +269,6 @@ class PyFmuDriver:
             )
             if not array_dim:
                 out_vals = out_vals[0]
-
         elif self.model_description.fmiVersion == "2.0":
             if array_dim:
                 print("FMU 2.0 does not support array dimensions, ignoring array_dim.")
@@ -260,7 +279,7 @@ class PyFmuDriver:
         return out_vals
 
     def set_fmu_bool(self, fmu_var: str, value: bool | list[bool]):
-        if type(value) is bool:
+        if type(value) is not list:
             value = [value]
         self.fmu_instance.setBoolean([self.fmu_var_refs[fmu_var]], value)
 
@@ -284,7 +303,7 @@ class PyFmuDriver:
         return out_vals
 
     def start(self):
-        print(f"{self.fmudriver_name} Start FMU driver...")
+        print(f"{self.fmudriver_name} Start FMU driver (no-op)...")
         print(f"{self.fmudriver_name} FMU driver is started.")
 
     def init_fmu(self):
@@ -354,7 +373,7 @@ class PyFmuDriver:
         self.fmu_instance.exitInitializationMode()
         self.fmu_time = self.start_time
 
-    def step_fmu(self, simtime_sec):
+    def step_fmu(self, simtime_sec, cur_step_sec):
         if not self.fmu_instance:
             return
 
@@ -404,34 +423,43 @@ class PyFmuDriver:
         # ------------------------------------------------------------
         # Do one step of the FMU
 
-        cur_step_sec = simtime_sec - self.fmu_time
-        if cur_step_sec < 0:
-            print(
-                f"{self.fmudriver_name} WARNING: Negative time step for simtime_sec='{simtime_sec}' fmu_time='{self.fmu_time}'"
-            )
-            return
-
         try:
-            if self.model_description.fmiVersion == "3.0":
-                (
-                    _eventEncountered,
-                    _terminate_simulation,
-                    _early_return,
-                    last_successful_time,
-                ) = self.fmu_instance.doStep(
-                    currentCommunicationPoint=self.fmu_time,
-                    communicationStepSize=cur_step_sec,
-                )
+            local_step_sec = cur_step_sec
+            last_fmu_time = self.fmu_time
+            while last_fmu_time < simtime_sec:
+                if self.model_description.fmiVersion == "3.0":
+                    (
+                        eventEncountered,
+                        terminate_simulation,
+                        early_return,
+                        last_successful_time,
+                    ) = self.fmu_instance.doStep(
+                        currentCommunicationPoint=last_fmu_time,
+                        communicationStepSize=local_step_sec,
+                    )
 
-            elif self.model_description.fmiVersion == "2.0":
-                self.fmu_instance.doStep(
-                    currentCommunicationPoint=self.fmu_time,
-                    communicationStepSize=cur_step_sec,
+                    # Validate that the step was successfully advanced
+                    if (
+                        eventEncountered
+                        or terminate_simulation
+                        or early_return
+                        or not math.isclose(
+                            last_successful_time - last_fmu_time, local_step_sec
+                        )
+                    ):
+                        print(
+                            f"{self.fmudriver_name} ERROR: FMU did not successfully advance by the target step time."
+                        )
+                        return
+                elif self.model_description.fmiVersion == "2.0":
+                    self.fmu_instance.doStep(
+                        currentCommunicationPoint=last_fmu_time,
+                        communicationStepSize=local_step_sec,
+                    )
+
+                last_fmu_time = round(
+                    last_fmu_time + local_step_sec, self.num_time_decimals
                 )
-                _event_encountered = False  # N/A for FMI 2.0
-                _terminate_simulation = False  # N/A for FMI 2.0
-                _early_return = False  # N/A for FMI 2.0
-            last_successful_time = self.fmu_time + cur_step_sec
         except Exception as e:
             print(f"{self.fmudriver_name} ERROR: {e}")
             self._running = False
@@ -439,8 +467,8 @@ class PyFmuDriver:
 
         # print(f"{self.fmudriver_name} Stepped FMU from {self.fmu_time} to {last_successful_time}")
 
-        # Advance the time
-        self.fmu_time = last_successful_time
+        # Advance the advanced FMU time
+        self.fmu_time = last_fmu_time
 
         # ------------------------------------------------------------
         # Read outputs from the FMU to update self.fmu_data
@@ -543,7 +571,7 @@ class PyFmuDriver:
                             print(
                                 f"{self.fmudriver_name} WARNING: Variable '{out_topic_var}' not found in self.fmu_data."
                             )
-                            print(f"Variables are: {self.fmu_data.keys()}")
+                            # print(f"Variables are: {self.fmu_data.keys()}")
 
                     metadata = middleware.Metadata(
                         out_topic, msg_type, timestamp_sim=timestamp
@@ -612,7 +640,17 @@ class PyFmuDriver:
                         return
 
                     # Process self.fmu_config_json
-                    self.load_config()
+                    (step_trigger_topic, step_trigger_msg_type) = self.load_config()
+
+                    # Subscribe to step trigger topic
+                    print(
+                        f"{self.fmudriver_name} Subscribing to step trigger topic '{step_trigger_topic}'"
+                    )
+                    self.transport.subscribe_raw(
+                        step_trigger_msg_type,
+                        step_trigger_topic,
+                        self.step_trigger_callback,
+                    )
 
                     # Subscribe to all of the topics specified in the sim config
                     self.transport.subscribe_all_raw(
@@ -678,30 +716,39 @@ class PyFmuDriver:
                     )
                 return
 
-    def clock_callback(self, data, _):
-        msg_data = data
+    def step_trigger_callback(self, payload):
+        if not self._running or not self._is_sim_started:
+            return
+
+        metadata = self.serializer.deserialize_metadata(payload)
+        if not metadata.is_sim_time_valid():
+            print(
+                f"{self.fmudriver_name} WARNING: Received a step trigger message with an invalid timestamp_sim."
+            )
+            return
+
+        timestamp_sim = metadata.timestamp_sim
+        simtime_sec = timestamp_sim.to_sec_rounded(self.num_time_decimals)
+
+        cur_step_sec = round(simtime_sec - self.fmu_time, self.num_time_decimals)
+        if cur_step_sec < 0.0:
+            print(
+                f"{self.fmudriver_name} WARNING: Negative time step for simtime_sec='{simtime_sec}' fmu_time='{self.fmu_time}'"
+            )
+            return
+        elif math.isclose(cur_step_sec, 0.0):
+            print(
+                f"{self.fmudriver_name} WARNING: Zero time step for simtime_sec='{simtime_sec}' fmu_time='{self.fmu_time}'"
+            )
+            return
 
         with self._processing_callback_lock:
-            if not self._running or not self._is_sim_started:
-                return
-
-            timestamp = aerosim_types.TimeStamp(
-                msg_data["timestamp_sim"]["sec"],
-                msg_data["timestamp_sim"]["nanosec"],
-            )
-            simtime_as_sec = timestamp.sec + timestamp.nanosec / 1.0e9
-
-            # print(
-            #     f"{self.fmudriver_name} Received aerosim.clock message with "
-            #     f"t={simtime_as_sec:.3f} sec"
-            # )
-
             # t1 = time.time()
-            self.step_fmu(simtime_as_sec)
+            self.step_fmu(simtime_sec, cur_step_sec)
             # t2 = time.time()
             # print(f"{self.fmudriver_name} step_fmu t={(t2-t1)*1000:.1f} ms")
 
-            self.publish_output_data(timestamp)
+            self.publish_output_data(timestamp_sim)
 
     def input_data_callback(self, payload):
         metadata = self.serializer.deserialize_metadata(payload)

--- a/aerosim-world/src/fmu_driver.rs
+++ b/aerosim-world/src/fmu_driver.rs
@@ -1,6 +1,6 @@
-use ::log::{info, warn};
+use ::log::{error, info, warn};
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{
     mpsc::{self, Receiver, Sender, TryRecvError},
     Arc, Mutex,
@@ -11,14 +11,11 @@ use pyo3::prelude::*;
 use serde_json::Value;
 
 use fmi::fmi2::import::Fmi2Import;
-use fmi::fmi3::import::Fmi3Import;
-use fmi::fmi3::instance::CoSimulation;
-use fmi::schema::{
-    fmi3::{ArrayableVariableTrait, VariableType},
-    traits::FmiModelDescription,
-};
-use fmi::traits::{FmiImport, FmiInstance};
+use fmi::fmi3::{instance::CoSimulation, schema::Causality};
+use fmi::schema::traits::FmiModelDescription;
+use fmi::traits::FmiInstance;
 
+use aerosim_core::math::round_to_decimal_places;
 use aerosim_data::{
     middleware::{
         CallbackClosureRaw, Metadata, Middleware, MiddlewareEnum, MiddlewareRaw,
@@ -28,9 +25,12 @@ use aerosim_data::{
 };
 
 use crate::fmu_utils::{
-    fmi3_var_type_to_string, publish_aux_output_topics_fmu3, publish_component_output_topics_fmu3,
-    set_fmu3_from_json, set_init_value_fmu3,
+    publish_aux_output_topics_fmu3, publish_component_output_topics_fmu3, set_fmu3_from_json,
+    set_init_value_fmu3, Fmi3Model, Fmi3ModelVarInfo, Fmi3VarInfo, NUM_TIME_DECIMALS, TIME_SEC_TOL,
 };
+
+// ----------------------------------------------------------------------------
+// FmuDriver struct
 
 #[pyclass]
 pub struct FmuDriver {
@@ -43,15 +43,28 @@ pub struct FmuDriver {
     fmu_driver_thread_tx_stop: Option<Sender<bool>>,
 }
 
+// FmuDriver interface functions that are exposed as Python class methods
 #[pymethods]
 impl FmuDriver {
     #[new]
-    fn __new__(fmu_id: &str, working_dir: &str, _middleware_type: &str) -> Self {
+    fn __new__(fmu_id: &str, working_dir: &str, middleware_type: &str) -> Self {
+        let middleware_type_mod = match middleware_type {
+            "kafka" => "kafka",
+            "zenoh" => "zenoh",
+            _ => {
+                warn!(
+                    "Unsupported middleware type '{}', defaulting to 'zenoh'",
+                    middleware_type
+                );
+                "zenoh"
+            }
+        };
+
         let mut fmu_driver = FmuDriver {
             fmu_id: fmu_id.to_string(),
             working_dir: working_dir.to_string(),
             middleware: MiddlewareRegistry::new()
-                .get("zenoh")
+                .get(middleware_type_mod)
                 .expect("Couldn't create middleware."),
             runtime: Arc::new(
                 tokio::runtime::Runtime::new().expect("Couldn't create tokio runtime."),
@@ -64,7 +77,6 @@ impl FmuDriver {
         let runtime = Arc::clone(&fmu_driver.runtime);
 
         // Channels to send received message data from subscriber to FMU Driver thread for processing
-        let (tx_clock_msg, rx_clock_msg) = mpsc::channel::<(JsonData, Metadata)>();
         let (tx_orchestrator_msg, rx_orchestrator_msg) = mpsc::channel::<(JsonData, Metadata)>();
 
         // Subscribe to orchestrator commands topic
@@ -72,7 +84,7 @@ impl FmuDriver {
             match middleware
                 .subscribe::<JsonData>("aerosim.orchestrator.commands", {
                     Box::new(move |data, metadata| {
-                        FmuDriver::handle_orchestrator_command_message(
+                        FmuDriver::receive_orchestrator_command_message(
                             data,
                             metadata,
                             &tx_orchestrator_msg,
@@ -92,25 +104,6 @@ impl FmuDriver {
             }
         });
 
-        // Subscribe to clock topic
-        runtime.block_on(async {
-            match middleware
-                .subscribe::<JsonData>("aerosim.clock", {
-                    let fmu_id = fmu_driver.fmu_id.clone();
-                    Box::new(move |data, metadata| {
-                        FmuDriver::handle_clock_message(data, metadata, &tx_clock_msg, &fmu_id);
-                        Ok(())
-                    })
-                })
-                .await
-            {
-                Ok(()) => {
-                    info!("Created aerosim.clock subscriber.")
-                }
-                Err(e) => warn!("Could not create aerosim.clock subscriber: {}", e),
-            }
-        });
-
         let (tx_stop, rx_stop): (Sender<bool>, Receiver<bool>) = mpsc::channel();
         fmu_driver.fmu_driver_thread_tx_stop = Some(tx_stop);
 
@@ -123,7 +116,6 @@ impl FmuDriver {
                 .spawn(move || {
                     runtime.block_on(FmuDriver::fmu_driver_main(
                         rx_stop,
-                        rx_clock_msg,
                         rx_orchestrator_msg,
                         middleware.clone(),
                         &fmu_id,
@@ -168,282 +160,11 @@ impl FmuDriver {
     }
 }
 
-pub struct Fmi3VarInfo {
-    pub fmu_var_ref: u32,
-    pub fmu_var_type: VariableType,
-    pub fmu_var_causality: fmi::fmi3::schema::Causality,
-    pub fmu_var_dim: Vec<u64>,
-    pub fmu_var_tot_dim: usize,
-}
-
-pub struct Fmi3ModelVarInfo {
-    pub fmu_var_info: HashMap<String, Fmi3VarInfo>,
-}
-
-impl Fmi3ModelVarInfo {
-    pub fn new(fmu_id: &str, fmi3_model: &Fmi3Model) -> Self {
-        let mut fmu_var_info: HashMap<String, Fmi3VarInfo> = HashMap::new();
-        let fmu_model_desc = fmi3_model.get_fmu_instance_ref().model_description();
-
-        // Collect all of the variable value references
-        let all_fmu_var_iter = itertools::chain!(
-            fmu_model_desc
-                .model_variables
-                .float64
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .float32
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int64
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int32
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int16
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int8
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint64
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint32
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint16
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint8
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .boolean
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .string
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-        );
-
-        for fmu_var in all_fmu_var_iter {
-            let fmu_var_ref = fmu_var.value_reference();
-            let fmu_var_name = fmu_var.name();
-            let fmu_var_type = fmu_var.data_type();
-            let fmu_var_causality = fmu_var.causality();
-            let fmu_var_dim: Vec<u64> = fmu_var
-                .dimensions()
-                .iter()
-                .map(|d| {
-                    d.start
-                        .expect("Error: Only dimensions using 'start' value are supported.")
-                        as u64
-                })
-                .collect();
-            let fmu_var_tot_dim: usize = fmu_var_dim
-                .iter()
-                .product::<u64>()
-                .try_into()
-                .expect("Unable to convert total dimension to usize");
-
-            info!(
-                "[{}] FMU ref={} var='{}', type={}, dim={:?}, causality={:?}",
-                fmu_id,
-                fmu_var_ref,
-                fmu_var_name,
-                fmi3_var_type_to_string(&fmu_var_type),
-                fmu_var_dim,
-                fmu_var_causality
-            );
-
-            fmu_var_info.insert(
-                fmu_var_name.to_string(),
-                Fmi3VarInfo {
-                    fmu_var_ref,
-                    fmu_var_type,
-                    fmu_var_causality,
-                    fmu_var_dim,
-                    fmu_var_tot_dim,
-                },
-            );
-        }
-
-        Self { fmu_var_info }
-    }
-
-    pub fn get_fmu_var_info(&self, var_name: &str) -> Option<&Fmi3VarInfo> {
-        self.fmu_var_info.get(var_name)
-    }
-}
-
-pub struct Fmi3Model {
-    #[allow(unused)]
-    fmu_import: Box<Fmi3Import>,
-    fmu_instance: fmi::fmi3::instance::InstanceCS<'static>,
-}
-
-impl Fmi3Model {
-    pub fn new(fmu_filename: PathBuf) -> Self {
-        // Allocate the import on the heap and leak it to get a 'static reference.
-        let fmu_import_box: Box<Fmi3Import> =
-            Box::new(fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file."));
-        let fmu_import_static: &'static Fmi3Import = Box::leak(fmu_import_box);
-
-        let fmu_instance = fmu_import_static
-            .instantiate_cs("instance1", false, true, false, false, &[])
-            .expect("Unable to instantiate FMU instance.");
-
-        // Rebuild the Box to deallocate it later.
-        let fmu_import =
-            unsafe { Box::from_raw(fmu_import_static as *const Fmi3Import as *mut Fmi3Import) };
-
-        let fmu_model_desc = fmu_import.model_description();
-
-        info!(
-            "Loaded FMU model name: {}, FMI ver: {}",
-            fmu_model_desc.model_name, fmu_model_desc.fmi_version
-        );
-
-        Self {
-            fmu_import,
-            fmu_instance,
-        }
-    }
-
-    pub fn get_fmu_instance_ref(&self) -> &fmi::fmi3::instance::InstanceCS<'static> {
-        &self.fmu_instance
-    }
-
-    pub fn get_fmu_instance_mut(&mut self) -> &mut fmi::fmi3::instance::InstanceCS<'static> {
-        &mut self.fmu_instance
-    }
-}
-
-// pub struct FmiModel<'a> {
-//     fmu_import: Box<Fmi3Import>,
-//     fmu_instance: fmi::fmi3::instance::InstanceCS<'a>,
-// }
-
-// impl<'a> FmiModel<'a> {
-//     pub fn new(fmu_filename: PathBuf) -> Self {
-//         // Allocate the import on the heap.
-//         let fmu_import: Box<Fmi3Import> =
-//             Box::new(fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file."));
-
-//         // Manually extend the lifetime of the reference to match 'a through a raw pointer.
-//         let fmu_import_ref: &'a Fmi3Import =
-//             unsafe { &*(fmu_import.as_ref() as *const Fmi3Import) };
-
-//         let fmu_instance = fmu_import_ref
-//             .instantiate_cs("instance1", false, true, false, false, &[])
-//             .expect("Unable to instantiate FMU instance.");
-
-//         Self {
-//             fmu_import,
-//             fmu_instance,
-//         }
-//     }
-// }
-
-// #[self_referencing]
-// pub struct FmiModel {
-//     fmu_import: Rc<Fmi3Import>,
-//     #[covariant]
-//     #[borrows(fmu_import)]
-//     fmu_instance: fmi::fmi3::instance::InstanceCS<'this>,
-// }
-
-// pub enum FmiImportEnum {
-//     Fmi2Import(Fmi2Import),
-//     Fmi3Import(Fmi3Import),
-// }
-
-// pub enum FmiInstanceEnum<'a> {
-//     Fmi2Instance(fmi::fmi2::instance::InstanceCS<'a>),
-//     Fmi3Instance(fmi::fmi3::instance::InstanceCS<'a>),
-// }
-
-// pub enum ModelDescriptionEnum<'a> {
-//     Fmi2ModelDescription(&'a fmi::fmi2::schema::Fmi2ModelDescription),
-//     Fmi3ModelDescription(&'a fmi::fmi3::schema::Fmi3ModelDescription),
-// }
-
-pub fn round_microsec(sec: f64) -> f64 {
-    (sec * 1e6_f64).round() / 1e6_f64
-}
-
-fn input_data_callback(
-    fmu_id_str: String,
-    serializer: SerializerEnum,
-    input_data_map: Arc<Mutex<HashMap<String, (Metadata, Value)>>>,
-) -> CallbackClosureRaw {
-    Box::new(move |payload: &[u8]| {
-        // Deserialize metadata from the incoming payload and determine the simulation timestamp.
-        // If the simulation timestamp is not valid, compute it based on the real-time platform timestamp.
-        let metadata = serializer
-            .deserialize_metadata(payload)
-            .ok_or(format!("Could not deserialize metadata from payload"))?;
-
-        let mut input_data_map_lock = input_data_map.lock().unwrap();
-
-        // Check if the topic already has data and if the received data is
-        // older than the existing data
-        if let Some((existing_metadata, _existing_data)) = input_data_map_lock.get(&metadata.topic)
-        {
-            if metadata.is_sim_time_valid()
-                && existing_metadata.is_sim_time_valid()
-                && metadata.timestamp_sim < existing_metadata.timestamp_sim
-            {
-                info!(
-                    "[{}] Ignoring older data for topic: {}",
-                    fmu_id_str, metadata.topic
-                );
-                return Ok(());
-            }
-        }
-
-        // Deserialize the payload into a JSON value and store it in the input data map
-        if let Some(msg_json) = deserialize_to_json(&metadata.type_name, &serializer, payload) {
-            input_data_map_lock.insert(metadata.topic.clone(), (metadata, msg_json));
-        } else {
-            warn!(
-                "[{}] Failed to deserialize payload for topic: {}",
-                fmu_id_str, metadata.topic
-            );
-        }
-
-        Ok(())
-    })
-}
-
 // Rust-only FmuDriverRust functions
 impl FmuDriver {
+    // Function for the FMU driver's main thread loop
     async fn fmu_driver_main(
         rx_stop: Receiver<bool>,
-        rx_clock_msg: Receiver<(JsonData, Metadata)>,
         rx_orchestrator_msg: Receiver<(JsonData, Metadata)>,
         middleware: Arc<MiddlewareEnum>,
         fmu_id: &str,
@@ -452,14 +173,13 @@ impl FmuDriver {
         info!("[{}] FMU Driver main thread started.", fmu_id);
 
         let mut running = true;
+        let mut is_sim_config_loaded = false;
+        let mut is_sim_started = false;
 
         let serializer = middleware.get_serializer();
 
         let mut fmu_config_json: Value = serde_json::Value::Null;
-
         let mut all_topics_to_subscribe: HashSet<(String, String)> = HashSet::new();
-        let mut aux_topics_to_subscribe: HashSet<String> = HashSet::new();
-        let mut aux_topics_to_publish: HashSet<String> = HashSet::new();
 
         let mut fmu_model: Option<Fmi3Model> = None;
         let mut fmu_model_var_info: Option<Fmi3ModelVarInfo> = None;
@@ -468,346 +188,32 @@ impl FmuDriver {
         let input_data_map: Arc<Mutex<HashMap<String, (Metadata, Value)>>> =
             Arc::new(Mutex::new(HashMap::new()));
 
+        // Channel to send received step trigger message data to this thread for processing
+        let (tx_step_msg, rx_step_msg) = mpsc::channel::<Metadata>();
+
         while running {
             // Check for a received orchestrator command message to process
             match rx_orchestrator_msg.try_recv() {
                 Ok((payload, metadata)) => {
-                    let msg_json = payload.get_data().expect("Unable to get JsonData payload.");
-                    let command = msg_json
-                        .get("command")
-                        .expect("Unable to get 'command' field from JSON.")
-                        .as_str()
-                        .expect("Unable to get 'command' as string.");
-
-                    info!(
-                        "[{}] FMU Driver thread processing topic: {} command {}",
-                        fmu_id, metadata.topic, command
-                    );
-
-                    match command {
-                        "stop" => {
-                            running = false;
-                        }
-
-                        "load_config" => {
-                            info!("[{}] Received orchestrator load command.", fmu_id);
-
-                            // ----------------------------------------------------------------
-                            // Load the FMU config into fmu_config_json
-
-                            let sim_config = msg_json
-                                .pointer("/parameters/sim_config")
-                                .expect(
-                                    "Unable to get ['parameters']['sim_config'] field from JSON",
-                                )
-                                .clone();
-
-                            for fmu_config in sim_config
-                                .get("fmu_models")
-                                .expect("Unable to get 'fmu_models' field from JSON")
-                                .as_array()
-                                .expect("Unable to get 'fmu_models' as array")
-                            {
-                                if fmu_config
-                                    .get("id")
-                                    .expect("Unable to get 'id' field from JSON")
-                                    .as_str()
-                                    .expect("Unable to get 'id' as string")
-                                    == fmu_id
-                                {
-                                    fmu_config_json = fmu_config.clone();
-                                    break;
-                                }
-                            }
-
-                            if fmu_config_json.is_null() {
-                                warn!("[{}] FMU ID not found in sim config.", fmu_id);
-                            }
-
-                            // info!("[{}] Received fmu_config: {:?}", fmu_id, fmu_config_json);
-
-                            // ----------------------------------------------------------------
-                            // Process fmu_config_json
-
-                            // TODO Refactor this block into load_config()
-                            {
-                                if let Some(in_topics) =
-                                    fmu_config_json.get("component_input_topics")
-                                {
-                                    for in_topic_info in in_topics
-                                        .as_array()
-                                        .expect("Unable to get 'component_input_topics' as array")
-                                    {
-                                        let in_topic = in_topic_info
-                                            .get("topic")
-                                            .expect("Unable to get 'topic' field from JSON")
-                                            .as_str()
-                                            .expect("Unable to get 'topic' as string");
-                                        let msg_type = in_topic_info
-                                            .get("msg_type")
-                                            .expect("Unable to get 'msg_type' field from JSON")
-                                            .as_str()
-                                            .expect("Unable to get 'msg_type' as string");
-                                        all_topics_to_subscribe
-                                            .insert((msg_type.to_string(), in_topic.to_string()));
-                                        // self.in_topic_data[in_topic] = {}
-                                    }
-                                }
-
-                                if let Some(aux_in_mapping) =
-                                    fmu_config_json.get("fmu_aux_input_mapping")
-                                {
-                                    for (in_topic_root, _) in aux_in_mapping
-                                        .as_object()
-                                        .expect("Unable to get 'fmu_aux_input_mapping' as object")
-                                    {
-                                        all_topics_to_subscribe.insert((
-                                            "aerosim::types::JsonData".to_string(),
-                                            in_topic_root.to_string(),
-                                        ));
-                                        aux_topics_to_subscribe.insert(in_topic_root.to_string());
-                                        // self.in_topic_data[in_topic_root] = {}
-                                    }
-                                }
-
-                                if let Some(aux_out_mapping) =
-                                    fmu_config_json.get("fmu_aux_output_mapping")
-                                {
-                                    for (out_topic_root, _) in aux_out_mapping
-                                        .as_object()
-                                        .expect("Unable to get 'fmu_aux_output_mapping' as object")
-                                    {
-                                        aux_topics_to_publish.insert(out_topic_root.to_string());
-                                        // self.out_topic_data[out_topic_root] = {}
-                                    }
-                                }
-                            }
-
-                            // ----------------------------------------------------------------
-                            // Subscribe to all of the topics specified in the sim config
-
-                            let all_topic_to_subscribe: Vec<(String, String)> =
-                                all_topics_to_subscribe.clone().into_iter().collect();
-
-                            info!(
-                                "[{}] Subscribing to topics: {:?}",
-                                fmu_id, all_topic_to_subscribe
-                            );
-
-                            let _ = middleware
-                                .subscribe_all_raw(
-                                    all_topic_to_subscribe,
-                                    input_data_callback(
-                                        fmu_id.to_string(),
-                                        middleware.get_serializer(),
-                                        Arc::clone(&input_data_map),
-                                    ),
-                                )
-                                .await;
-
-                            // ----------------------------------------------------------------
-                            // Load the FMU model file
-
-                            // TODO Refactor this block into load_fmu()
-                            {
-                                // ------------------------------------------------------------
-                                // FMU model file path processing
-
-                                let fmu_model_path = fmu_config_json
-                                    .get("fmu_model_path")
-                                    .expect("Unable to get 'fmu_model_path' field from JSON")
-                                    .as_str()
-                                    .expect("Unable to get 'fmu_model_path' as string");
-                                let mut fmu_model_path_buf =
-                                    Path::new(fmu_model_path).to_path_buf();
-
-                                // Check if file exists at fmu_model_path
-                                if !fmu_model_path_buf.exists() {
-                                    // If the FMU model path is not found, check if it is relative to
-                                    // the AeroSim root dir
-                                    let aerosim_root = match std::env::var("AEROSIM_ROOT") {
-                                        Ok(root_path) => root_path,
-                                        Err(_) => "".to_string(),
-                                    };
-
-                                    fmu_model_path_buf =
-                                        Path::new(&aerosim_root).join(fmu_model_path);
-                                }
-
-                                if !fmu_model_path_buf.exists() {
-                                    // If the FMU model path is still not found, check if it is relative to
-                                    // the working directory
-                                    fmu_model_path_buf =
-                                        Path::new(&working_dir).join(fmu_model_path);
-                                }
-
-                                let fmu_filename = fmu_model_path_buf
-                                    .canonicalize()
-                                    .expect("Unable to canonicalize fmu_model_path");
-
-                                info!("[{}] Loading FMU file: {:?}", fmu_id, fmu_filename);
-
-                                // Peek the model description to check the FMI version
-                                let min_model_desc = fmi::import::peek_descr_path(&fmu_filename)
-                                    .expect("Unable to peek model description.");
-
-                                if min_model_desc.version_string() == "2.0" {
-                                    // ------------------------------------------------------------
-                                    // FMI 2.0 model processing
-
-                                    let _fmu_import: Fmi2Import =
-                                        fmi::import::from_path(&fmu_filename)
-                                            .expect("Unable to import FMU file.");
-
-                                    // TODO implement FMI2 model processing
-                                } else if min_model_desc.version_string() == "3.0" {
-                                    // ------------------------------------------------------------
-                                    // FMI 3.0 model processing
-
-                                    // Load the FMU instance
-                                    fmu_model = Some(Fmi3Model::new(fmu_filename));
-                                    fmu_model_var_info = Some(Fmi3ModelVarInfo::new(
-                                        fmu_id,
-                                        fmu_model.as_ref().unwrap(),
-                                    ));
-                                }
-                            }
-
-                            // ----------------------------------------------------------------
-                            // After loading FMU model file to populate fmu_var_refs, pass
-                            // through the world origin values as initial values if the FMU has
-                            // variables for it
-
-                            if let Some(fmu_var_info_ref) = fmu_model_var_info.as_ref() {
-                                if fmu_var_info_ref
-                                    .get_fmu_var_info("world_origin_latitude")
-                                    .is_some()
-                                    && fmu_var_info_ref
-                                        .get_fmu_var_info("world_origin_longitude")
-                                        .is_some()
-                                    && fmu_var_info_ref
-                                        .get_fmu_var_info("world_origin_altitude")
-                                        .is_some()
-                                {
-                                    fmu_config_json["fmu_initial_vals"]["world_origin_latitude"] =
-                                        sim_config["world"]["origin"]["latitude"].clone();
-                                    fmu_config_json["fmu_initial_vals"]["world_origin_longitude"] =
-                                        sim_config["world"]["origin"]["longitude"].clone();
-                                    fmu_config_json["fmu_initial_vals"]["world_origin_altitude"] =
-                                        sim_config["world"]["origin"]["altitude"].clone();
-                                }
-                            }
-
-                            // self._is_sim_config_loaded = True
-
-                            info!("[{}] Done loading sim config.", fmu_id);
-                        }
-
-                        "start" => {
-                            info!("[{}] Received orchestrator start command.", fmu_id);
-                            {
-                                // # Save sim start time from the orchestrator (not used anywhere yet)
-                                let sim_start_time_sec = msg_json
-                                .pointer("/parameters/sim_start_time/sec")
-                                .expect(
-                                    "Unable to get ['parameters']['sim_start_time']['sec'] field from JSON",
-                                ).as_i64().expect("Unable to get 'sec' as i64");
-                                let sim_start_time_nanosec = msg_json
-                                .pointer("/parameters/sim_start_time/nanosec")
-                                .expect(
-                                    "Unable to get ['parameters']['sim_start_time']['nanosec'] field from JSON",
-                                ).as_u64().expect("Unable to get 'nanosec' as u64");
-                                let sim_start_time = TimeStamp::new(
-                                    sim_start_time_sec as i32,
-                                    sim_start_time_nanosec as u32,
-                                );
-                                info!("[{}] Sim start time: {:?}", fmu_id, sim_start_time);
-                            }
-
-                            let initial_timestamp = metadata.timestamp_sim;
-
-                            // Initialize the FMU model instance to be ready to start stepping
-                            {
-                                // self.init_fmu()
-                                if let (Some(fmu_model_mut), Some(fmu_model_var_info_ref)) =
-                                    (fmu_model.as_mut(), fmu_model_var_info.as_ref())
-                                {
-                                    let fmu_instance = fmu_model_mut.get_fmu_instance_mut();
-
-                                    // Set initial values for FMU variables set in the "fmu_initial_vals" config
-                                    if let Some(fmu_init_vals_json) =
-                                        fmu_config_json.get("fmu_initial_vals")
-                                    {
-                                        let fmu_init_vals_obj =
-                                            fmu_init_vals_json.as_object().expect(
-                                                "Unable to get 'fmu_initial_vals' as a JSON object",
-                                            );
-                                        for (init_var, init_value) in fmu_init_vals_obj {
-                                            if let Some(fmu_var_info) =
-                                                fmu_model_var_info_ref.get_fmu_var_info(init_var)
-                                            {
-                                                set_init_value_fmu3(
-                                                    fmu_id,
-                                                    init_var,
-                                                    init_value,
-                                                    fmu_var_info,
-                                                    fmu_instance,
-                                                );
-                                            } else {
-                                                warn!(
-                                                    "[{}] FMU variable '{}' not found in model info.",
-                                                    fmu_id, init_var
-                                                );
-                                            }
-                                        }
-                                    }
-
-                                    // Call FMU API to execute its 'enter initialization mode' function
-                                    // to process the initial values set above
-                                    FmiInstance::enter_initialization_mode(
-                                        fmu_instance,
-                                        None,
-                                        fmu_time,
-                                        None,
-                                    );
-
-                                    // Call FMU API to execute its 'exit initialization mode' function
-                                    // to be ready to start stepping
-                                    FmiInstance::exit_initialization_mode(fmu_instance);
-
-                                    // Publish initial value output topics for initial timestamp
-                                    publish_component_output_topics_fmu3(
-                                        fmu_id,
-                                        &fmu_config_json,
-                                        fmu_model_var_info_ref,
-                                        fmu_instance,
-                                        initial_timestamp,
-                                        &middleware,
-                                        &serializer,
-                                    )
-                                    .await;
-
-                                    publish_aux_output_topics_fmu3(
-                                        fmu_id,
-                                        &fmu_config_json,
-                                        fmu_model_var_info_ref,
-                                        fmu_instance,
-                                        initial_timestamp,
-                                        &middleware,
-                                    )
-                                    .await;
-                                }
-                            }
-
-                            // self._is_sim_started = True
-                        }
-
-                        "load_scene_graph" => { /* No-op for FMU driver */ }
-
-                        &_ => {
-                            warn!("Unknown orchestrator command: {}", command);
-                        }
-                    };
+                    FmuDriver::process_orchestrator_command_message(
+                        fmu_id,
+                        working_dir,
+                        &middleware,
+                        &serializer,
+                        &payload,
+                        &metadata,
+                        &tx_step_msg,
+                        &mut running,
+                        &mut is_sim_config_loaded,
+                        &mut is_sim_started,
+                        &mut fmu_config_json,
+                        &mut all_topics_to_subscribe,
+                        &mut fmu_time,
+                        &mut fmu_model,
+                        &mut fmu_model_var_info,
+                        &input_data_map,
+                    )
+                    .await;
                 }
                 Err(TryRecvError::Disconnected) => {
                     running = false;
@@ -815,144 +221,28 @@ impl FmuDriver {
                 Err(TryRecvError::Empty) => { /* pass to continue looping */ }
             }
 
-            // Check for a received clock message to process
-            match rx_clock_msg.try_recv() {
-                Ok((payload, _metadata)) => {
-                    let msg_json = payload.get_data().expect("Unable to get JsonData payload.");
-                    let timestamp_sim = TimeStamp::new(
-                        msg_json["timestamp_sim"]["sec"].as_i64().unwrap() as i32,
-                        msg_json["timestamp_sim"]["nanosec"].as_u64().unwrap() as u32,
-                    );
-
-                    info!(
-                        "[{}] FMU Driver thread processing clock step: {:?}",
-                        fmu_id, timestamp_sim
-                    );
-
-                    // ------------------------------------------------------------------------
-                    // Step the FMU model instance
-
-                    {
-                        // self.step_fmu(simtime_as_sec)
-                        if let (Some(fmu_model_mut), Some(fmu_model_var_info_ref)) =
-                            (fmu_model.as_mut(), fmu_model_var_info.as_ref())
-                        {
-                            let simtime_sec = round_microsec(timestamp_sim.to_sec());
-                            let cur_step_sec = simtime_sec - fmu_time;
-                            if cur_step_sec < 0.0 {
-                                warn!(
-                                    "[{}] Negative time step for simtime_sec='{}' fmu_time='{}'",
-                                    fmu_id, simtime_sec, fmu_time
-                                );
-                            } else {
-                                let fmu_instance = fmu_model_mut.get_fmu_instance_mut();
-
-                                // ------------------------------------------------------------
-                                // Write inputs to the FMU
-
-                                // Process every input topic that has been received and stored in input_data_map
-                                {
-                                    let mut input_data_map_lock = input_data_map.lock().unwrap();
-                                    let cur_input_data = input_data_map_lock.drain();
-
-                                    for (input_topic, (in_msg_metadata, in_msg_json)) in
-                                        cur_input_data
-                                    {
-                                        // info!(
-                                        //     "[{}] Writing input topic '{}' at timestamp: {:?}",
-                                        //     fmu_id, input_topic, in_msg_metadata.timestamp_sim
-                                        // );
-
-                                        let in_msg_flat_fields =
-                                            TypeSupport::get_flat_fields_from_json_object(
-                                                &in_msg_json,
-                                                "",
-                                            );
-
-                                        let aux_in_var_map = fmu_config_json
-                                            .get("fmu_aux_input_mapping")
-                                            .and_then(|aux_in_mapping| {
-                                                aux_in_mapping.get(&input_topic)
-                                            })
-                                            .and_then(|aux_in_mapping| aux_in_mapping.as_object());
-
-                                        // Iterate through the flat fields and set the FMU variables
-                                        for in_msg_var in in_msg_flat_fields {
-                                            set_fmu3_from_json(
-                                                &in_msg_var,
-                                                &in_msg_json,
-                                                &in_msg_metadata,
-                                                aux_in_var_map,
-                                                fmu_id,
-                                                fmu_model_var_info_ref,
-                                                fmu_instance,
-                                            );
-                                        }
-                                    }
-                                }
-
-                                // ------------------------------------------------------------
-                                // Do one step of the FMU
-
-                                let no_set_fmu_state_prior_to_current_point = false;
-
-                                let mut event_handling_needed = false;
-                                let mut terminate_simulation = false;
-                                let mut early_return = false;
-                                let mut last_successful_time: f64 = 0.0;
-
-                                fmu_instance.do_step(
-                                    fmu_time,
-                                    cur_step_sec,
-                                    no_set_fmu_state_prior_to_current_point,
-                                    &mut event_handling_needed,
-                                    &mut terminate_simulation,
-                                    &mut early_return,
-                                    &mut last_successful_time,
-                                );
-
-                                // Advance the time
-                                fmu_time = round_microsec(last_successful_time);
-
-                                info!("[{}] FMU step done, fmu_time: {}", fmu_id, fmu_time);
-                            }
-                        }
-                    }
-
-                    // ------------------------------------------------------------------------
-                    // Publish output data for the current timestamp
-
-                    if let (Some(fmu_model_mut), Some(fmu_model_var_info_ref)) =
-                        (fmu_model.as_mut(), fmu_model_var_info.as_ref())
-                    {
-                        let fmu_instance = fmu_model_mut.get_fmu_instance_mut();
-
-                        publish_component_output_topics_fmu3(
+            // Check for a received step trigger message to process
+            if running && is_sim_started {
+                match rx_step_msg.try_recv() {
+                    Ok(metadata) => {
+                        FmuDriver::process_step_trigger_message(
                             fmu_id,
                             &fmu_config_json,
-                            fmu_model_var_info_ref,
-                            fmu_instance,
-                            timestamp_sim,
                             &middleware,
                             &serializer,
-                        )
-                        .await;
-
-                        publish_aux_output_topics_fmu3(
-                            fmu_id,
-                            &fmu_config_json,
-                            fmu_model_var_info_ref,
-                            fmu_instance,
-                            timestamp_sim,
-                            &middleware,
+                            &metadata,
+                            &mut fmu_time,
+                            &mut fmu_model,
+                            &mut fmu_model_var_info,
+                            &input_data_map,
                         )
                         .await;
                     }
+                    Err(TryRecvError::Disconnected) => {
+                        running = false;
+                    }
+                    Err(TryRecvError::Empty) => { /* pass to continue looping */ }
                 }
-                Err(TryRecvError::Disconnected) => {
-                    running = false;
-                }
-                Err(TryRecvError::Empty) => { /* pass to continue looping */ }
             }
 
             // Check for stop flag to shutdown the thread
@@ -967,228 +257,687 @@ impl FmuDriver {
                 }
                 Err(TryRecvError::Empty) => { /* pass to continue looping */ }
             }
+
+            tokio::task::yield_now().await;
         }
 
-        tokio::task::yield_now().await;
+        // FMU Driver main thread is stopping
 
         info!("[{}] FMU Driver main thread stopped.", fmu_id);
     }
 
-    fn handle_orchestrator_command_message(
+    // Function to load the FMU config to parse the input topics and populate all_topics_to_subscribe,
+    // and return a tuple of (step_trigger_topic, step_trigger_msg_type)
+    fn load_fmu_config(
+        fmu_id: &str,
+        fmu_config_json: &Value,
+        all_topics_to_subscribe: &mut HashSet<(String, String)>,
+    ) -> (String, String) {
+        if let Some(in_topics) = fmu_config_json.get("component_input_topics") {
+            for in_topic_info in in_topics
+                .as_array()
+                .expect("Unable to get 'component_input_topics' as array")
+            {
+                let in_topic = in_topic_info
+                    .get("topic")
+                    .expect("Unable to get 'topic' field from JSON")
+                    .as_str()
+                    .expect("Unable to get 'topic' as string");
+                let msg_type = in_topic_info
+                    .get("msg_type")
+                    .expect("Unable to get 'msg_type' field from JSON")
+                    .as_str()
+                    .expect("Unable to get 'msg_type' as string");
+                all_topics_to_subscribe.insert((msg_type.to_string(), in_topic.to_string()));
+            }
+        }
+
+        if let Some(aux_in_mapping) = fmu_config_json.get("fmu_aux_input_mapping") {
+            for (in_topic_root, _) in aux_in_mapping
+                .as_object()
+                .expect("Unable to get 'fmu_aux_input_mapping' as object")
+            {
+                all_topics_to_subscribe.insert((
+                    "aerosim::types::JsonData".to_string(),
+                    in_topic_root.to_string(),
+                ));
+            }
+        }
+
+        if let Some(step_topic_val) = fmu_config_json.get("step_trigger_topic") {
+            let step_topic_obj = step_topic_val
+                .as_object()
+                .expect("Unable to process 'step_trigger_topic' as a JSON object.");
+            let step_trigger_topic = step_topic_obj
+                .get("topic")
+                .and_then(|v| v.as_str())
+                .expect("Unable to parse 'step_trigger_topic.topic' from JSON.");
+            let step_trigger_msg_type = step_topic_obj
+                .get("msg_type")
+                .and_then(|v| v.as_str())
+                .expect("Unable to parse 'step_trigger_topic.msg_type' from JSON.");
+            return (
+                step_trigger_topic.to_string(),
+                step_trigger_msg_type.to_string(),
+            );
+        } else {
+            info!("[{}] Unable to find 'step_trigger_topic' field in FMU config. Using base 'aerosim.clock' topic as step trigger.", fmu_id);
+            return (
+                "aerosim.clock".to_string(),
+                "aerosim::types::JsonData".to_string(),
+            );
+        }
+    }
+
+    // Function to load the FMU model instance from the config FMU model file path, returning
+    // the Fmi3Model object and the Fmi3ModelVarInfo struct of the FMU's variable metadata
+    fn load_fmu_model(
+        fmu_id: &str,
+        working_dir: &str,
+        fmu_config_json: &Value,
+    ) -> (Option<Fmi3Model>, Option<Fmi3ModelVarInfo>) {
+        // ------------------------------------------------------------
+        // FMU model file path processing
+
+        let fmu_model_path = fmu_config_json
+            .get("fmu_model_path")
+            .expect("Unable to get 'fmu_model_path' field from JSON")
+            .as_str()
+            .expect("Unable to get 'fmu_model_path' as string");
+        let mut fmu_model_path_buf = Path::new(fmu_model_path).to_path_buf();
+
+        // Check if file exists at fmu_model_path
+        if !fmu_model_path_buf.exists() {
+            // If the FMU model path is not found, check if it is relative to
+            // the AeroSim root dir
+            let aerosim_root = match std::env::var("AEROSIM_ROOT") {
+                Ok(root_path) => root_path,
+                Err(_) => "".to_string(),
+            };
+
+            fmu_model_path_buf = Path::new(&aerosim_root).join(fmu_model_path);
+        }
+
+        if !fmu_model_path_buf.exists() {
+            // If the FMU model path is still not found, check if it is relative to
+            // the working directory
+            fmu_model_path_buf = Path::new(&working_dir).join(fmu_model_path);
+        }
+
+        let fmu_filename = std::path::absolute(fmu_model_path_buf)
+            .expect("Unable to resolve FMU model path as an absolute path.");
+
+        info!("[{}] Loading FMU file: {:?}", fmu_id, fmu_filename);
+
+        // Peek the model description to check the FMI version
+        let min_model_desc =
+            fmi::import::peek_descr_path(&fmu_filename).expect("Unable to peek model description.");
+
+        if min_model_desc.version_string() == "2.0" {
+            // ------------------------------------------------------------
+            // FMI 2.0 model processing
+
+            let _fmu_import: Fmi2Import =
+                fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file.");
+
+            todo!("FMI 2.0 model processing not implemented yet.");
+        } else if min_model_desc.version_string() == "3.0" {
+            // ------------------------------------------------------------
+            // FMI 3.0 model processing
+
+            // Load the FMU instance
+            let fmu_model = Some(Fmi3Model::new(fmu_filename));
+            let fmu_model_var_info =
+                Some(Fmi3ModelVarInfo::new(fmu_id, fmu_model.as_ref().unwrap()));
+
+            return (fmu_model, fmu_model_var_info);
+        }
+
+        (None, None)
+    }
+
+    // Function to initialize the FMU model (set initial values from the config, publish
+    // the initial output topics with values for t=0)
+    async fn initialize_fmu_model(
+        fmu_id: &str,
+        fmu_config_json: &Value,
+        fmu_time: f64,
+        initial_timestamp: &TimeStamp,
+        middleware: &Arc<MiddlewareEnum>,
+        serializer: &SerializerEnum,
+        fmu_model: &mut Option<Fmi3Model>,
+        fmu_model_var_info: &mut Option<Fmi3ModelVarInfo>,
+    ) {
+        if let (Some(fmu_model_mut), Some(fmu_model_var_info_ref)) =
+            (fmu_model.as_mut(), fmu_model_var_info.as_ref())
+        {
+            let fmu_instance = fmu_model_mut.get_fmu_instance_mut();
+
+            // Set initial values for FMU variables set in the "fmu_initial_vals" config
+            let fmu_init_vals_obj: Option<&serde_json::Map<String, Value>> = fmu_config_json
+                .get("fmu_initial_vals")
+                .and_then(|v| v.as_object());
+            let mut fmu_input_var_init_vals: Vec<(&String, &Value, &Fmi3VarInfo)> = Vec::new();
+            if let Some(fmu_init_vals) = fmu_init_vals_obj {
+                for (init_var, init_value) in fmu_init_vals {
+                    if let Some(fmu_var_info) = fmu_model_var_info_ref.get_fmu_var_info(init_var) {
+                        set_init_value_fmu3(
+                            fmu_id,
+                            init_var,
+                            init_value,
+                            fmu_var_info,
+                            fmu_instance,
+                        );
+                        if fmu_var_info.fmu_var_causality == Causality::Input {
+                            fmu_input_var_init_vals.push((init_var, init_value, fmu_var_info));
+                        }
+                    } else {
+                        warn!(
+                            "[{}] FMU variable '{}' not found in model info.",
+                            fmu_id, init_var
+                        );
+                    }
+                }
+            }
+
+            // Call FMU API to execute its 'enter initialization mode' function
+            // to process the initial values set above
+            FmiInstance::enter_initialization_mode(fmu_instance, None, fmu_time, None);
+
+            // Re-set initial values for FMU input-type variables because they get reset to zero
+            // during FmiInstance::enter_initialization_mode()
+            for (init_var, init_value, fmu_var_info) in fmu_input_var_init_vals {
+                set_init_value_fmu3(fmu_id, init_var, init_value, fmu_var_info, fmu_instance);
+            }
+
+            // Call FMU API to execute its 'exit initialization mode' function
+            // to be ready to start stepping
+            FmiInstance::exit_initialization_mode(fmu_instance);
+
+            // Publish initial value output topics for initial timestamp
+            publish_component_output_topics_fmu3(
+                fmu_id,
+                &fmu_config_json,
+                fmu_model_var_info_ref,
+                fmu_instance,
+                initial_timestamp,
+                middleware,
+                serializer,
+            )
+            .await;
+
+            publish_aux_output_topics_fmu3(
+                fmu_id,
+                &fmu_config_json,
+                fmu_model_var_info_ref,
+                fmu_instance,
+                initial_timestamp,
+                &middleware,
+            )
+            .await;
+        }
+    }
+
+    // Function to execute one sim clock step of the FMU model
+    fn step_fmu_model(
+        fmu_id: &str,
+        fmu_config_json: &Value,
+        simtime_sec: f64,
+        cur_step_sec: f64,
+        fmu_time: &mut f64,
+        fmu_model: &mut Option<Fmi3Model>,
+        fmu_model_var_info: &mut Option<Fmi3ModelVarInfo>,
+        input_data_map: &Arc<Mutex<HashMap<String, (Metadata, Value)>>>,
+    ) {
+        if let (Some(fmu_model_mut), Some(fmu_model_var_info_ref)) =
+            (fmu_model.as_mut(), fmu_model_var_info.as_ref())
+        {
+            let fmu_instance = fmu_model_mut.get_fmu_instance_mut();
+
+            // ------------------------------------------------------------
+            // Write inputs to the FMU
+
+            // Process every input topic that has been received and stored in input_data_map
+            {
+                let mut input_data_map_lock = input_data_map.lock().unwrap();
+                let cur_input_data = input_data_map_lock.drain();
+
+                for (input_topic, (in_msg_metadata, in_msg_json)) in cur_input_data {
+                    // info!(
+                    //     "[{}] Writing input topic '{}' at timestamp: {:?}",
+                    //     fmu_id, input_topic, in_msg_metadata.timestamp_sim
+                    // );
+
+                    let in_msg_flat_fields =
+                        TypeSupport::get_flat_fields_from_json_object(&in_msg_json, "");
+
+                    // TODO Move this parsing to load_fmu_config()
+                    let aux_in_var_map = fmu_config_json
+                        .get("fmu_aux_input_mapping")
+                        .and_then(|aux_in_mapping| aux_in_mapping.get(&input_topic))
+                        .and_then(|aux_in_mapping| aux_in_mapping.as_object());
+
+                    // Iterate through the flat fields and set the FMU variables
+                    for in_msg_var in in_msg_flat_fields {
+                        set_fmu3_from_json(
+                            &in_msg_var,
+                            &in_msg_json,
+                            &in_msg_metadata,
+                            aux_in_var_map,
+                            fmu_id,
+                            fmu_model_var_info_ref,
+                            fmu_instance,
+                        );
+                    }
+                }
+            }
+
+            // ------------------------------------------------------------
+            // Do one step of the FMU
+
+            let no_set_fmu_state_prior_to_current_point = false;
+            let local_step_sec: f64 = cur_step_sec;
+
+            let mut last_fmu_time = *fmu_time;
+            while last_fmu_time < simtime_sec {
+                let mut event_handling_needed = false;
+                let mut terminate_simulation = false;
+                let mut early_return = false;
+                let mut last_successful_time: f64 = 0.0;
+
+                fmu_instance.do_step(
+                    last_fmu_time,
+                    local_step_sec,
+                    no_set_fmu_state_prior_to_current_point,
+                    &mut event_handling_needed,
+                    &mut terminate_simulation,
+                    &mut early_return,
+                    &mut last_successful_time,
+                );
+
+                // Validate that the step was successfully advanced
+                let time_stepped = last_successful_time - last_fmu_time;
+                if event_handling_needed
+                    || terminate_simulation
+                    || early_return
+                    || (time_stepped - local_step_sec).abs() > TIME_SEC_TOL
+                {
+                    error!(
+                        "[{}] FMU did not successfully advance by the target step time.",
+                        fmu_id
+                    );
+                    return;
+                }
+
+                // Advance the time
+                last_fmu_time =
+                    round_to_decimal_places(last_fmu_time + local_step_sec, NUM_TIME_DECIMALS);
+            }
+
+            // Save the completed step's time
+            *fmu_time = last_fmu_time;
+
+            // info!("[{}] FMU step done, fmu_time: {}", fmu_id, fmu_time);
+        }
+    }
+
+    // Callback function for receiving the orchestrator command messages (passes them to FMU driver's
+    // main thread loop)
+    fn receive_orchestrator_command_message(
         payload: JsonData,
         metadata: Metadata,
         tx_orchestrator_msg: &Sender<(JsonData, Metadata)>,
     ) {
         tx_orchestrator_msg
             .send((payload, metadata))
-            .expect("UNable to send orchestrator msg data to FMU Driver thread.");
+            .expect("Unable to send orchestrator msg data to FMU Driver thread.");
     }
 
-    fn handle_clock_message(
-        payload: JsonData,
-        metadata: Metadata,
-        tx_clock_msg: &Sender<(JsonData, Metadata)>,
-        _fmu_id: &str,
+    // Function for processing orchestrator command messages to load the
+    // sim config, start the FMU driver, and stop the FMU driver (run on the FMU driver's
+    // main thread loop)
+    async fn process_orchestrator_command_message(
+        fmu_id: &str,
+        working_dir: &str,
+        middleware: &Arc<MiddlewareEnum>,
+        serializer: &SerializerEnum,
+        payload: &JsonData,
+        metadata: &Metadata,
+        tx_step_msg: &Sender<Metadata>,
+        running: &mut bool,
+        is_sim_config_loaded: &mut bool,
+        is_sim_started: &mut bool,
+        fmu_config_json: &mut Value,
+        all_topics_to_subscribe: &mut HashSet<(String, String)>,
+        fmu_time: &mut f64,
+        fmu_model: &mut Option<Fmi3Model>,
+        fmu_model_var_info: &mut Option<Fmi3ModelVarInfo>,
+        input_data_map: &Arc<Mutex<HashMap<String, (Metadata, Value)>>>,
     ) {
-        tx_clock_msg
-            .send((payload, metadata))
-            .expect("UNable to send clock msg data to FMU Driver thread.");
-    }
-}
+        let msg_json = payload.get_data().expect("Unable to get JsonData payload.");
+        let command = msg_json
+            .get("command")
+            .expect("Unable to get 'command' field from JSON.")
+            .as_str()
+            .expect("Unable to get 'command' as string.");
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fmi::fmi3::instance::Common;
-
-    #[test]
-    fn test_fmu_float64_array() {
-        let aerosim_root = match std::env::var("AEROSIM_ROOT") {
-            Ok(root_path) => root_path,
-            Err(_) => "".to_string(),
-        };
-
-        // Import FMU model
-
-        let fmu_import: Fmi3Import =
-            fmi::import::from_path(aerosim_root + "/examples/fmu/evtol_vehicle_fmu.fmu")
-                .expect("Unable to import FMU file.");
-
-        let fmu_model_desc = fmu_import.model_description();
-        println!("Model name: {}", fmu_model_desc.model_name);
-
-        // Parse FMU variable info
-
-        let all_fmu_var_iter = itertools::chain!(
-            fmu_model_desc
-                .model_variables
-                .float32
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .float64
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
+        info!(
+            "[{}] FMU Driver received orchestrator command: {}",
+            fmu_id, command
         );
 
-        println!("Loaded FMU variable info:");
-        for fmu_var in all_fmu_var_iter {
-            let fmu_var_ref = fmu_var.value_reference();
-            let fmu_var_name = fmu_var.name();
-            let fmu_var_type = fmu_var.data_type();
-            let fmu_var_dim = fmu_var.dimensions();
-            let fmu_var_caus = fmu_var.causality();
-            println!(
-                "FMU ref={} var={} type={} dim={:?} causality={:?}",
-                fmu_var_ref,
-                fmu_var_name,
-                fmi3_var_type_to_string(&fmu_var_type),
-                fmu_var_dim,
-                fmu_var_caus
-            );
+        if command == "stop" {
+            // ----------------------------------------------------------------
+            // Orchestrator stop command
+
+            *running = false;
+            return;
         }
 
-        // Load FMU instance
-        let mut fmu_instance: fmi::fmi3::instance::InstanceCS = fmu_import
-            .instantiate_cs("instance1", false, true, false, false, &[])
-            .expect("Unable to instantiate FMU.");
+        if *is_sim_config_loaded == false && command == "load_config" {
+            // ----------------------------------------------------------------
+            // Orchestrator load config command
 
-        println!(
-            "FMU instance name: {}, version: {}",
-            FmiInstance::name(&fmu_instance),
-            FmiInstance::get_version(&fmu_instance)
-        );
+            // Load the FMU config into fmu_config_json
+            let sim_config = msg_json
+                .pointer("/parameters/sim_config")
+                .expect("Unable to get ['parameters']['sim_config'] field from JSON")
+                .clone();
 
-        let mut fmu_time: f64 = 0.0;
+            for fmu_config in sim_config
+                .get("fmu_models")
+                .expect("Unable to get 'fmu_models' field from JSON")
+                .as_array()
+                .expect("Unable to get 'fmu_models' as array")
+            {
+                if fmu_config
+                    .get("id")
+                    .expect("Unable to get 'id' field from JSON")
+                    .as_str()
+                    .expect("Unable to get 'id' as string")
+                    == fmu_id
+                {
+                    *fmu_config_json = fmu_config.clone();
+                    break;
+                }
+            }
 
-        FmiInstance::enter_initialization_mode(&mut fmu_instance, None, fmu_time, None);
-        FmiInstance::exit_initialization_mode(&mut fmu_instance);
+            if fmu_config_json.is_null() {
+                warn!("[{}] FMU ID not found in sim config.", fmu_id);
+            }
 
-        // Read then set array variable values
-        let mut init_ned_m = [0.0, 0.0, 0.0];
-        let init_ned_m_vrs = [40];
-        let _ = fmu_instance.get_float64(&init_ned_m_vrs, &mut init_ned_m);
-        println!("Initial, init_ned_m: {:?}", init_ned_m);
-        init_ned_m = [1.0, 2.0, 3.0];
-        let _ = fmu_instance.set_float64(&init_ned_m_vrs, &init_ned_m);
-        println!("Before step, init_ned_m: {:?}", init_ned_m);
+            // info!("[{}] Received fmu_config: {:?}", fmu_id, fmu_config_json);
 
-        // Step FMU
-        let communication_step_size = 0.02;
-        let no_set_fmu_state_prior_to_current_point = false;
+            // Process fmu_config_json
+            let (step_trigger_topic, step_trigger_msg_type) =
+                FmuDriver::load_fmu_config(fmu_id, &fmu_config_json, all_topics_to_subscribe);
 
-        let mut event_handling_needed = false;
-        let mut terminate_simulation = false;
-        let mut early_return = false;
-        let mut last_successful_time: f64 = 0.0;
+            // Subscribe to step trigger topic
+            info!(
+                "[{}] Subscribing to step trigger topic: '{}'",
+                fmu_id, step_trigger_topic
+            );
+            match middleware
+                .subscribe_raw(&step_trigger_msg_type, &step_trigger_topic, {
+                    let tx_step_msg_copy = tx_step_msg.clone();
+                    let serializer_copy = middleware.get_serializer();
+                    Box::new(move |payload| {
+                        let metadata = serializer_copy
+                            .deserialize_metadata(payload)
+                            .expect("Unable to deserialize metadata.");
+                        FmuDriver::receive_step_trigger_message(metadata, &tx_step_msg_copy);
+                        Ok(())
+                    })
+                })
+                .await
+            {
+                Ok(()) => {
+                    info!("[{}] Created step trigger subscriber.", fmu_id)
+                }
+                Err(e) => warn!(
+                    "[{}] Could not create step trigger subscriber: {}",
+                    fmu_id, e
+                ),
+            }
 
-        fmu_instance.do_step(
+            // Subscribe to all of the topics specified in the sim config
+            let all_topic_to_subscribe: Vec<(String, String)> =
+                all_topics_to_subscribe.clone().into_iter().collect();
+
+            info!(
+                "[{}] Subscribing to topics: {:?}",
+                fmu_id, all_topic_to_subscribe
+            );
+
+            let _ = middleware
+                .subscribe_all_raw(
+                    all_topic_to_subscribe,
+                    FmuDriver::process_fmu_input_data(
+                        fmu_id.to_string(),
+                        middleware.get_serializer(),
+                        Arc::clone(&input_data_map),
+                    ),
+                )
+                .await;
+
+            // Load the FMU model file
+            (*fmu_model, *fmu_model_var_info) =
+                FmuDriver::load_fmu_model(fmu_id, working_dir, &fmu_config_json);
+
+            // After loading FMU model file to populate fmu_var_refs, pass
+            // through the world origin values as initial values if the FMU has
+            // variables for it
+            if let Some(fmu_var_info_ref) = fmu_model_var_info.as_ref() {
+                if fmu_var_info_ref
+                    .get_fmu_var_info("world_origin_latitude")
+                    .is_some()
+                    && fmu_var_info_ref
+                        .get_fmu_var_info("world_origin_longitude")
+                        .is_some()
+                    && fmu_var_info_ref
+                        .get_fmu_var_info("world_origin_altitude")
+                        .is_some()
+                {
+                    fmu_config_json["fmu_initial_vals"]["world_origin_latitude"] =
+                        sim_config["world"]["origin"]["latitude"].clone();
+                    fmu_config_json["fmu_initial_vals"]["world_origin_longitude"] =
+                        sim_config["world"]["origin"]["longitude"].clone();
+                    fmu_config_json["fmu_initial_vals"]["world_origin_altitude"] =
+                        sim_config["world"]["origin"]["altitude"].clone();
+                }
+            }
+
+            *is_sim_config_loaded = true;
+            info!("[{}] Done loading sim config.", fmu_id);
+            return;
+        }
+
+        if *is_sim_started == false && command == "start" {
+            // ----------------------------------------------------------------
+            // Orchestrator start command
+
+            {
+                // # Save sim start time from the orchestrator (not used anywhere yet)
+                let sim_start_time_sec = msg_json
+                    .pointer("/parameters/sim_start_time/sec")
+                    .expect("Unable to get ['parameters']['sim_start_time']['sec'] field from JSON")
+                    .as_i64()
+                    .expect("Unable to get 'sec' as i64");
+                let sim_start_time_nanosec = msg_json
+                    .pointer("/parameters/sim_start_time/nanosec")
+                    .expect(
+                        "Unable to get ['parameters']['sim_start_time']['nanosec'] field from JSON",
+                    )
+                    .as_u64()
+                    .expect("Unable to get 'nanosec' as u64");
+                let sim_start_time =
+                    TimeStamp::new(sim_start_time_sec as i32, sim_start_time_nanosec as u32);
+                info!("[{}] Sim start time: {:?}", fmu_id, sim_start_time);
+            }
+
+            let initial_timestamp = metadata.timestamp_sim;
+
+            //Initialize the FMU model instance to be ready to start stepping
+            FmuDriver::initialize_fmu_model(
+                fmu_id,
+                &fmu_config_json,
+                *fmu_time,
+                &initial_timestamp,
+                &middleware,
+                &serializer,
+                fmu_model,
+                fmu_model_var_info,
+            )
+            .await;
+
+            *is_sim_started = true;
+            return;
+        }
+
+        info!("[{}] Ignoring orchestrator command: {}", fmu_id, command);
+    }
+
+    // Callback function for receiving the messages to trigger FMU steps (passes them to FMU driver's
+    // main thread loop)
+    fn receive_step_trigger_message(metadata: Metadata, tx_step_msg: &Sender<Metadata>) {
+        tx_step_msg
+            .send(metadata)
+            .expect("Unable to send step trigger msg to FMU Driver thread.");
+    }
+
+    // Function for processing the received messages to trigger FMU steps (run on the FMU driver's
+    // main thread loop)
+    async fn process_step_trigger_message(
+        fmu_id: &str,
+        fmu_config_json: &Value,
+        middleware: &Arc<MiddlewareEnum>,
+        serializer: &SerializerEnum,
+        metadata: &Metadata,
+        fmu_time: &mut f64,
+        fmu_model: &mut Option<Fmi3Model>,
+        fmu_model_var_info: &mut Option<Fmi3ModelVarInfo>,
+        input_data_map: &Arc<Mutex<HashMap<String, (Metadata, Value)>>>,
+    ) {
+        if !metadata.is_sim_time_valid() {
+            warn!(
+                "[{}] Received a step trigger message with an invalid timestamp_sim.",
+                fmu_id
+            );
+            return;
+        }
+        let timestamp_sim = &metadata.timestamp_sim;
+
+        // info!(
+        //     "[{}] FMU Driver thread processing step trigger for timestamp_sim: {:?}",
+        //     fmu_id, timestamp_sim
+        // );
+
+        let simtime_sec = timestamp_sim.to_sec_rounded(NUM_TIME_DECIMALS);
+        let mut cur_step_sec = simtime_sec - *fmu_time;
+        if cur_step_sec < 0.0 {
+            warn!(
+                "[{}] Negative time step for simtime_sec='{}' fmu_time='{}'",
+                fmu_id, simtime_sec, fmu_time
+            );
+            return;
+        } else if cur_step_sec < f64::EPSILON {
+            warn!(
+                "[{}] Zero time step for simtime_sec='{}' fmu_time='{}'",
+                fmu_id, simtime_sec, fmu_time
+            );
+            return;
+        }
+        cur_step_sec = round_to_decimal_places(cur_step_sec, NUM_TIME_DECIMALS);
+
+        // ----------------------------------------------------------------
+        // Step the FMU model instance
+
+        FmuDriver::step_fmu_model(
+            fmu_id,
+            fmu_config_json,
+            simtime_sec,
+            cur_step_sec,
             fmu_time,
-            communication_step_size,
-            no_set_fmu_state_prior_to_current_point,
-            &mut event_handling_needed,
-            &mut terminate_simulation,
-            &mut early_return,
-            &mut last_successful_time,
+            fmu_model,
+            fmu_model_var_info,
+            input_data_map,
         );
 
-        fmu_time = last_successful_time;
+        // ----------------------------------------------------------------
+        // Publish output data for the current timestamp
 
-        // Read array variable values
-        let mut init_ned_m = [0.0, 0.0, 0.0];
-        let init_ned_m_vrs = [40];
-        let _ = fmu_instance.get_float64(&init_ned_m_vrs, &mut init_ned_m);
-        println!(
-            "After step, fmu_time: {}, init_ned_m: {:?}",
-            fmu_time, init_ned_m
-        );
+        if let (Some(fmu_model_mut), Some(fmu_model_var_info_ref)) =
+            (fmu_model.as_mut(), fmu_model_var_info.as_ref())
+        {
+            let fmu_instance = fmu_model_mut.get_fmu_instance_mut();
+
+            publish_component_output_topics_fmu3(
+                fmu_id,
+                fmu_config_json,
+                fmu_model_var_info_ref,
+                fmu_instance,
+                &timestamp_sim,
+                middleware,
+                serializer,
+            )
+            .await;
+
+            publish_aux_output_topics_fmu3(
+                fmu_id,
+                fmu_config_json,
+                fmu_model_var_info_ref,
+                fmu_instance,
+                &timestamp_sim,
+                middleware,
+            )
+            .await;
+        }
     }
 
-    #[test]
-    fn test_fmu_int64_array() {
-        let aerosim_root = match std::env::var("AEROSIM_ROOT") {
-            Ok(root_path) => root_path,
-            Err(_) => "".to_string(),
-        };
+    // Callback function for processing the FMU's input topic messages (deserializes and saves the
+    // data into the input data map)
+    fn process_fmu_input_data(
+        fmu_id_str: String,
+        serializer: SerializerEnum,
+        input_data_map: Arc<Mutex<HashMap<String, (Metadata, Value)>>>,
+    ) -> CallbackClosureRaw {
+        Box::new(move |payload: &[u8]| {
+            // Deserialize metadata from the incoming payload and determine the simulation timestamp.
+            // If the simulation timestamp is not valid, compute it based on the real-time platform timestamp.
+            let metadata = serializer
+                .deserialize_metadata(payload)
+                .ok_or(format!("Could not deserialize metadata from payload"))?;
 
-        // Import FMU model
+            let mut input_data_map_lock = input_data_map.lock().unwrap();
 
-        let fmu_import: Fmi3Import =
-            fmi::import::from_path(aerosim_root + "/examples/fmu/Int64ArrayBouncingBall.fmu")
-                .expect("Unable to import FMU file.");
+            // Check if the topic already has data and if the received data is
+            // older than the existing data
+            if let Some((existing_metadata, _existing_data)) =
+                input_data_map_lock.get(&metadata.topic)
+            {
+                if metadata.is_sim_time_valid()
+                    && existing_metadata.is_sim_time_valid()
+                    && metadata.timestamp_sim < existing_metadata.timestamp_sim
+                {
+                    info!(
+                        "[{}] Ignoring older data for topic: {}",
+                        fmu_id_str, metadata.topic
+                    );
+                    return Ok(());
+                }
+            }
 
-        let fmu_model_desc = fmu_import.model_description();
-        println!("Model name: {}", fmu_model_desc.model_name);
+            // Deserialize the payload into a JSON value and store it in the input data map
+            if let Some(msg_json) = deserialize_to_json(&metadata.type_name, &serializer, payload) {
+                input_data_map_lock.insert(metadata.topic.clone(), (metadata, msg_json));
+            } else {
+                warn!(
+                    "[{}] Failed to deserialize payload for topic: {}",
+                    fmu_id_str, metadata.topic
+                );
+            }
 
-        // Parse FMU variable info
-
-        let all_fmu_var_iter = itertools::chain!(
-            fmu_model_desc
-                .model_variables
-                .float32
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .float64
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int64
-                .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-        );
-
-        println!("Loaded FMU variable info:");
-        for fmu_var in all_fmu_var_iter {
-            let fmu_var_ref = fmu_var.value_reference();
-            let fmu_var_name = fmu_var.name();
-            let fmu_var_type = fmu_var.data_type();
-            let fmu_var_dim = fmu_var.dimensions();
-            let fmu_var_caus = fmu_var.causality();
-            println!(
-                "FMU ref={} var={} type={} dim={:?} causality={:?}",
-                fmu_var_ref,
-                fmu_var_name,
-                fmi3_var_type_to_string(&fmu_var_type),
-                fmu_var_dim,
-                fmu_var_caus
-            );
-        }
-
-        // Load FMU instance
-        let mut fmu_instance: fmi::fmi3::instance::InstanceCS = fmu_import
-            .instantiate_cs("instance1", false, true, false, false, &[])
-            .expect("Unable to instantiate FMU.");
-
-        println!(
-            "FMU instance name: {}, version: {}",
-            FmiInstance::name(&fmu_instance),
-            FmiInstance::get_version(&fmu_instance)
-        );
-
-        let fmu_time: f64 = 0.0;
-
-        FmiInstance::enter_initialization_mode(&mut fmu_instance, None, fmu_time, None);
-        FmiInstance::exit_initialization_mode(&mut fmu_instance);
-
-        // Read then set array variable values
-        let mut h_int_array = [0, 0, 0];
-        let h_int_array_vrs = [8];
-        let res = fmu_instance.get_int64(&h_int_array_vrs, &mut h_int_array);
-        println!("{:?}", res);
-        println!("Initial, h_int_array: {:?}", h_int_array);
-
-        h_int_array = [11, 22, 33];
-        let res = fmu_instance.set_int64(&h_int_array_vrs, &h_int_array);
-        println!("{:?}", res);
-        println!("Before step, h_int_array: {:?}", h_int_array);
-
-        h_int_array = [0, 0, 0];
-        let res = fmu_instance.get_int64(&h_int_array_vrs, &mut h_int_array);
-        println!("{:?}", res);
-        println!("Written, h_int_array: {:?}", h_int_array);
+            Ok(())
+        })
     }
 }

--- a/aerosim-world/src/fmu_utils.rs
+++ b/aerosim-world/src/fmu_utils.rs
@@ -1,22 +1,327 @@
 use log::{info, warn};
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde_json::Value;
 
-use fmi::fmi3::instance::Common;
-use fmi::fmi3::schema::VariableType;
+use fmi::fmi3::{import::Fmi3Import, instance::Common, schema::VariableType};
+use fmi::schema::fmi3::ArrayableVariableTrait;
+use fmi::traits::{FmiImport, FmiInstance};
 
-use aerosim_data::middleware::{
-    Metadata, Middleware, MiddlewareEnum, MiddlewareRaw, Serializer, SerializerEnum,
+use aerosim_data::{
+    middleware::{Metadata, Middleware, MiddlewareEnum, MiddlewareRaw, Serializer, SerializerEnum},
+    types::{
+        sensor::{ADSB, GNSS, IMU},
+        AircraftEffectorCommand, AutopilotCommand, EffectorState, FlightControlCommand, JsonData,
+        PrimaryFlightDisplayData, TimeStamp, TrajectoryVisualization, TypeSupport, VehicleState,
+    },
+    AerosimMessage,
 };
-use aerosim_data::types::{
-    sensor::{ADSB, GNSS, IMU},
-    AircraftEffectorCommand, AutopilotCommand, EffectorState, FlightControlCommand, JsonData,
-    PrimaryFlightDisplayData, TimeStamp, TrajectoryVisualization, TypeSupport, VehicleState,
-};
-use aerosim_data::AerosimMessage;
 
-use crate::fmu_driver::{Fmi3ModelVarInfo, Fmi3VarInfo};
+pub const NUM_TIME_DECIMALS: u32 = 6; // round time to microsec decimal place
+pub const TIME_SEC_TOL: f64 = 1e-6;
+
+// ----------------------------------------------------------------------------
+// Fmi3VarInfo and Fmi3ModelVarInfo structs to collect all of loaded variable info
+
+pub struct Fmi3VarInfo {
+    pub fmu_var_ref: u32,
+    pub fmu_var_type: VariableType,
+    pub fmu_var_causality: fmi::fmi3::schema::Causality,
+    pub fmu_var_dim: Vec<u64>,
+    pub fmu_var_tot_dim: usize,
+}
+
+impl Clone for Fmi3VarInfo {
+    fn clone(&self) -> Self {
+        let fmu_var_ref = self.fmu_var_ref;
+        let fmu_var_type = match self.fmu_var_type {
+            VariableType::FmiFloat32 => VariableType::FmiFloat32,
+            VariableType::FmiFloat64 => VariableType::FmiFloat64,
+            VariableType::FmiInt8 => VariableType::FmiInt8,
+            VariableType::FmiUInt8 => VariableType::FmiUInt8,
+            VariableType::FmiInt16 => VariableType::FmiInt16,
+            VariableType::FmiUInt16 => VariableType::FmiUInt16,
+            VariableType::FmiInt32 => VariableType::FmiInt32,
+            VariableType::FmiUInt32 => VariableType::FmiUInt32,
+            VariableType::FmiInt64 => VariableType::FmiInt64,
+            VariableType::FmiUInt64 => VariableType::FmiUInt64,
+            VariableType::FmiBoolean => VariableType::FmiBoolean,
+            VariableType::FmiString => VariableType::FmiString,
+            VariableType::FmiBinary => VariableType::FmiBinary,
+        };
+        let fmu_var_causality = self.fmu_var_causality;
+        let fmu_var_dim = self.fmu_var_dim.clone();
+        let fmu_var_tot_dim = self.fmu_var_tot_dim;
+
+        Self {
+            fmu_var_ref,
+            fmu_var_type,
+            fmu_var_causality,
+            fmu_var_dim,
+            fmu_var_tot_dim,
+        }
+    }
+}
+
+pub struct Fmi3ModelVarInfo {
+    pub fmu_var_info: HashMap<String, Fmi3VarInfo>,
+}
+
+impl Fmi3ModelVarInfo {
+    pub fn new(fmu_id: &str, fmi3_model: &Fmi3Model) -> Self {
+        let mut fmu_var_info: HashMap<String, Fmi3VarInfo> = HashMap::new();
+        let fmu_model_desc = fmi3_model.get_fmu_instance_ref().model_description();
+
+        // Collect all of the variable value references
+        let all_fmu_var_iter = itertools::chain!(
+            fmu_model_desc
+                .model_variables
+                .float64
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .float32
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .int64
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .int32
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .int16
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .int8
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .uint64
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .uint32
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .uint16
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .uint8
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .boolean
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+            fmu_model_desc
+                .model_variables
+                .string
+                .iter()
+                .map(|v| v as &dyn ArrayableVariableTrait),
+        );
+
+        for fmu_var in all_fmu_var_iter {
+            let fmu_var_ref = fmu_var.value_reference();
+            let fmu_var_name = fmu_var.name();
+            let fmu_var_type = fmu_var.data_type();
+            let fmu_var_causality = fmu_var.causality();
+            let fmu_var_dim: Vec<u64> = fmu_var
+                .dimensions()
+                .iter()
+                .map(|d| {
+                    d.start
+                        .expect("Error: Only dimensions using 'start' value are supported.")
+                        as u64
+                })
+                .collect();
+            let fmu_var_tot_dim: usize = fmu_var_dim
+                .iter()
+                .product::<u64>()
+                .try_into()
+                .expect("Unable to convert total dimension to usize");
+
+            info!(
+                "[{}] FMU ref={} var='{}', type={}, dim={:?}, causality={:?}",
+                fmu_id,
+                fmu_var_ref,
+                fmu_var_name,
+                fmi3_var_type_to_string(&fmu_var_type),
+                fmu_var_dim,
+                fmu_var_causality
+            );
+
+            fmu_var_info.insert(
+                fmu_var_name.to_string(),
+                Fmi3VarInfo {
+                    fmu_var_ref,
+                    fmu_var_type,
+                    fmu_var_causality,
+                    fmu_var_dim,
+                    fmu_var_tot_dim,
+                },
+            );
+        }
+
+        Self { fmu_var_info }
+    }
+
+    pub fn get_fmu_var_info(&self, var_name: &str) -> Option<&Fmi3VarInfo> {
+        self.fmu_var_info.get(var_name)
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Fmi3Model struct to combine Import and Instance (that has a reference to
+// the Import bindings). The Import lifetime is made static through a leaked
+// Box pointer to guarantee it outlives the instance.
+
+pub struct Fmi3Model {
+    #[allow(unused)]
+    fmu_import: Box<Fmi3Import>,
+    fmu_instance: fmi::fmi3::instance::InstanceCS<'static>,
+}
+
+impl Fmi3Model {
+    pub fn new(fmu_filename: PathBuf) -> Self {
+        // Allocate the import on the heap and leak it to get a 'static reference.
+        let fmu_import_box: Box<Fmi3Import> =
+            Box::new(fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file."));
+
+        if std::env::consts::OS == "windows" {
+            // Add extracted lib path to system path so any dependency libs can also be found and loaded
+            let archive_path = fmu_import_box.archive_path();
+            let mut shared_lib_path = fmu_import_box
+                .shared_lib_path("")
+                .expect("Unable to get FMU shared lib path.");
+            let _ = shared_lib_path.pop(); // remove blank '.dll' that shared_lib_path() adds at the end
+            let compined_lib_path: String = std::path::absolute(archive_path.join(shared_lib_path))
+                .expect("Unable to get absolute file path to extracted FMU shared libs.")
+                .to_str()
+                .unwrap_or_else(|| "")
+                .to_string();
+
+            // Join the new path entry with the existing PATH
+            let current_path = std::env::var("PATH").unwrap_or_else(|_| String::new());
+            let new_path: String = if current_path.is_empty() {
+                compined_lib_path
+            } else {
+                format!("{};{}", current_path, compined_lib_path)
+            };
+            std::env::set_var("PATH", new_path);
+        } else if std::env::consts::OS == "linux" {
+            // TODO Update the Linux path like above
+        }
+
+        let fmu_import_static: &'static Fmi3Import = Box::leak(fmu_import_box);
+
+        let fmu_instance = fmu_import_static
+            .instantiate_cs("instance1", false, true, false, false, &[])
+            .expect("Unable to instantiate FMU instance.");
+
+        // Rebuild the Box to deallocate it later.
+        let fmu_import =
+            unsafe { Box::from_raw(fmu_import_static as *const Fmi3Import as *mut Fmi3Import) };
+
+        let fmu_model_desc = fmu_import.model_description();
+
+        info!(
+            "Loaded FMU model name: {}, FMI ver: {}",
+            fmu_model_desc.model_name, fmu_model_desc.fmi_version
+        );
+
+        Self {
+            fmu_import,
+            fmu_instance,
+        }
+    }
+
+    pub fn get_fmu_instance_ref(&self) -> &fmi::fmi3::instance::InstanceCS<'static> {
+        &self.fmu_instance
+    }
+
+    pub fn get_fmu_instance_mut(&mut self) -> &mut fmi::fmi3::instance::InstanceCS<'static> {
+        &mut self.fmu_instance
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Alternative way to deal with Fmi3Model import lifetime through a raw pointer
+
+// pub struct FmiModel<'a> {
+//     fmu_import: Box<Fmi3Import>,
+//     fmu_instance: fmi::fmi3::instance::InstanceCS<'a>,
+// }
+
+// impl<'a> FmiModel<'a> {
+//     pub fn new(fmu_filename: PathBuf) -> Self {
+//         // Allocate the import on the heap.
+//         let fmu_import: Box<Fmi3Import> =
+//             Box::new(fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file."));
+
+//         // Manually extend the lifetime of the reference to match 'a through a raw pointer.
+//         let fmu_import_ref: &'a Fmi3Import =
+//             unsafe { &*(fmu_import.as_ref() as *const Fmi3Import) };
+
+//         let fmu_instance = fmu_import_ref
+//             .instantiate_cs("instance1", false, true, false, false, &[])
+//             .expect("Unable to instantiate FMU instance.");
+
+//         Self {
+//             fmu_import,
+//             fmu_instance,
+//         }
+//     }
+// }
+
+// ----------------------------------------------------------------------------
+// Alternative way to deal with Fmi3Model import lifetime using 'ouroboros' crate
+
+// #[self_referencing]
+// pub struct FmiModel {
+//     fmu_import: Rc<Fmi3Import>,
+//     #[covariant]
+//     #[borrows(fmu_import)]
+//     fmu_instance: fmi::fmi3::instance::InstanceCS<'this>,
+// }
+
+// ----------------------------------------------------------------------------
+// FMI 2.0 + 3.0 enum type placeholders to be implemented in the future
+
+// pub enum FmiImportEnum {
+//     Fmi2Import(Fmi2Import),
+//     Fmi3Import(Fmi3Import),
+// }
+
+// pub enum FmiInstanceEnum<'a> {
+//     Fmi2Instance(fmi::fmi2::instance::InstanceCS<'a>),
+//     Fmi3Instance(fmi::fmi3::instance::InstanceCS<'a>),
+// }
+
+// pub enum ModelDescriptionEnum<'a> {
+//     Fmi2ModelDescription(&'a fmi::fmi2::schema::Fmi2ModelDescription),
+//     Fmi3ModelDescription(&'a fmi::fmi3::schema::Fmi3ModelDescription),
+// }
+
+// ---------------------------------------------------------------------------
+// FMU Utility functions
 
 pub fn fmi3_var_type_to_string(var_type: &VariableType) -> String {
     return match var_type {
@@ -348,6 +653,114 @@ pub fn set_fmu3_from_json(
     // );
 }
 
+pub fn get_fmu3_f64(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<f64> {
+    let mut values: Vec<f64> = vec![0.0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_float64(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_f32(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<f32> {
+    let mut values: Vec<f32> = vec![0.0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_float32(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_i64(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<i64> {
+    let mut values: Vec<i64> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_int64(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_i32(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<i32> {
+    let mut values: Vec<i32> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_int32(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_i16(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<i16> {
+    let mut values: Vec<i16> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_int16(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_i8(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<i8> {
+    let mut values: Vec<i8> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_int8(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_u64(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<u64> {
+    let mut values: Vec<u64> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_uint64(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_u32(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<u32> {
+    let mut values: Vec<u32> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_uint32(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_u16(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<u16> {
+    let mut values: Vec<u16> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_uint16(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_u8(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<u8> {
+    let mut values: Vec<u8> = vec![0; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_uint8(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_bool(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<bool> {
+    let mut values: Vec<bool> = vec![false; fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_boolean(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
+pub fn get_fmu3_string(
+    fmu_var_info: &Fmi3VarInfo,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
+) -> Vec<String> {
+    let mut values: Vec<String> = vec![String::new(); fmu_var_info.fmu_var_tot_dim];
+    let _ = fmu_instance.get_string(&[fmu_var_info.fmu_var_ref], &mut values);
+    values
+}
+
 pub fn set_json_from_fmu3(
     fmu_id: &str,
     fmu_var_name: &str,
@@ -371,69 +784,18 @@ pub fn set_json_from_fmu3(
 
         // Get the FMU variable value based on its type
         let fmu_value: serde_json::Value = match fmu_var_info.fmu_var_type {
-            VariableType::FmiFloat64 => {
-                let mut values: Vec<f64> = vec![0.0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_float64(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiFloat32 => {
-                let mut values: Vec<f32> = vec![0.0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_float32(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiInt64 => {
-                let mut values: Vec<i64> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_int64(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiInt32 => {
-                let mut values: Vec<i32> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_int32(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiInt16 => {
-                let mut values: Vec<i16> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_int16(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiInt8 => {
-                let mut values: Vec<i8> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_int8(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiUInt64 => {
-                let mut values: Vec<u64> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_uint64(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiUInt32 => {
-                let mut values: Vec<u32> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_uint32(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiUInt16 => {
-                let mut values: Vec<u16> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_uint16(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiUInt8 => {
-                let mut values: Vec<u8> = vec![0; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_uint8(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiBoolean => {
-                let mut values: Vec<bool> = vec![false; fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_boolean(&[fmu_var_info.fmu_var_ref], &mut values);
-                values.into()
-            }
-            VariableType::FmiString => {
-                let mut values: Vec<String> = vec![String::new(); fmu_var_info.fmu_var_tot_dim];
-                let _ = fmu_instance.get_string(&[fmu_var_info.fmu_var_ref], &mut values);
-                // Convert Vec<String> to serde_json::Value
-                serde_json::Value::Array(
-                    values.into_iter().map(serde_json::Value::String).collect(),
-                )
-            }
+            VariableType::FmiFloat64 => get_fmu3_f64(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiFloat32 => get_fmu3_f32(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiInt64 => get_fmu3_i64(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiInt32 => get_fmu3_i32(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiInt16 => get_fmu3_i16(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiInt8 => get_fmu3_i8(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiUInt64 => get_fmu3_u64(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiUInt32 => get_fmu3_u32(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiUInt16 => get_fmu3_u16(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiUInt8 => get_fmu3_u8(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiBoolean => get_fmu3_bool(fmu_var_info, fmu_instance).into(),
+            VariableType::FmiString => get_fmu3_string(fmu_var_info, fmu_instance).into(),
             _ => {
                 warn!(
                     "[{}] Unsupported FMU variable type for field '{}'.",
@@ -475,7 +837,7 @@ pub async fn publish_component_output_topics_fmu3(
     fmu_config_json: &serde_json::Value,
     fmu_model_var_info: &Fmi3ModelVarInfo,
     fmu_instance: &mut fmi::fmi3::instance::InstanceCS<'_>,
-    timestamp: TimeStamp,
+    timestamp: &TimeStamp,
     middleware: &Arc<MiddlewareEnum>,
     serializer: &SerializerEnum,
 ) {
@@ -505,7 +867,7 @@ pub async fn publish_component_output_topics_fmu3(
                     .to_string();
             }
 
-            let metadata = Metadata::new(out_topic, msg_type, Some(timestamp), None);
+            let metadata = Metadata::new(out_topic, msg_type, Some(*timestamp), None);
 
             let serialized_msg: Vec<u8> = match msg_type {
                 "aerosim::types::VehicleState" => pack_raw_aerosim_fmu_msg::<VehicleState>(
@@ -657,7 +1019,7 @@ pub async fn publish_aux_output_topics_fmu3(
     fmu_config_json: &serde_json::Value,
     fmu_model_var_info: &Fmi3ModelVarInfo,
     fmu_instance: &mut fmi::fmi3::instance::InstanceCS<'_>,
-    timestamp: TimeStamp,
+    timestamp: &TimeStamp,
     middleware: &Arc<MiddlewareEnum>,
 ) {
     // Pack and publish auxiliary output topics as JsonData
@@ -703,7 +1065,7 @@ pub async fn publish_aux_output_topics_fmu3(
             let data_msg = JsonData::new(data_value);
 
             let _ = middleware
-                .publish(out_topic, &data_msg, Some(timestamp))
+                .publish(out_topic, &data_msg, Some(*timestamp))
                 .await;
 
             // info!(

--- a/aerosim-world/src/orchestrator.rs
+++ b/aerosim-world/src/orchestrator.rs
@@ -25,7 +25,9 @@ use crate::{
     sim_clock::SimClock,
 };
 use aerosim_data::{
-    middleware::{Middleware, MiddlewareEnum, MiddlewareRaw, MiddlewareRegistry, Serializer},
+    middleware::{
+        Metadata, Middleware, MiddlewareEnum, MiddlewareRaw, MiddlewareRegistry, Serializer,
+    },
     types::{JsonData, TimeStamp},
 };
 
@@ -306,22 +308,50 @@ impl Orchestrator {
         let runtime = self.runtime.take().expect("Tokio runtime not initialized");
 
         // Initialize communication channel between sync topics subscriber and the orchestrator.
-        let (tx_msg, rx_msg) = mpsc::channel::<(TimeStamp, String)>();
+        let (tx_msg, rx_msg) = mpsc::channel::<(TimeStamp, Metadata)>();
 
-        // Process sync topic data from sim config
-        let mut sync_topic_data: Vec<(String, TimeStamp)> = vec![];
-        for sync_topic_dict in sim_config["orchestrator"]["sync_topics"]
-            .as_array()
-            .unwrap()
+        // Process tick group data from sim config
+        // tick_group_data is Vec of tuples ("clock_topic", Vec of tuples ("topic", interval TimeStamp))
+        let mut tick_group_data: Vec<(String, Vec<(String, TimeStamp)>)> = vec![];
+        for (idx, tick_group_array) in sim_config
+            .pointer("/orchestrator/tick_groups")
+            .and_then(|v| v.as_array())
+            .expect("Unable to parse 'tick_groups' as array.")
+            .iter()
+            .enumerate()
         {
-            if let Some(topic_str) = sync_topic_dict["topic"].as_str() {
-                let interval: TimeStamp = match sync_topic_dict["interval_ms"].as_u64() {
-                    Some(interval_ms) => TimeStamp::from_millis(interval_ms),
-                    None => TimeStamp::new(0, 0),
-                };
-                sync_topic_data.push((topic_str.to_string(), interval));
+            let tick_group_obj = tick_group_array
+                .as_object()
+                .expect("Unable to parse 'tick_group' entry as a JSON object.");
+            let clock_topic = tick_group_obj
+                .get("clock_topic")
+                .and_then(|v| v.as_str())
+                .expect("Unable to parse 'clock_topic' as a string in tick group config.");
+            let sync_topics = tick_group_obj
+                .get("sync_topics")
+                .expect("Unable to find 'sync_topics' in tick group config.");
+
+            let mut sync_topic_data: Vec<(String, TimeStamp)> = vec![];
+            for sync_topic_dict in sync_topics
+                .as_array()
+                .expect("Unable to parse 'sync_topics' as a JSON array.")
+            {
+                if let Some(topic_str) = sync_topic_dict["topic"].as_str() {
+                    let interval: TimeStamp = match sync_topic_dict["interval_ms"].as_u64() {
+                        Some(interval_ms) => TimeStamp::from_millis(interval_ms),
+                        None => TimeStamp::new(0, 0),
+                    };
+                    sync_topic_data.push((topic_str.to_string(), interval));
+                }
             }
+
+            info!(
+                "Tick group index {} added with clock_topic: '{}', sync_topics: {:?}",
+                idx, clock_topic, sync_topic_data
+            );
+            tick_group_data.push((clock_topic.to_string(), sync_topic_data));
         }
+        info!("Processed {} tick groups.", tick_group_data.len());
 
         // Retrieve all topics from sim config.
         let mut all_topics: HashSet<(String, String)> = HashSet::new();
@@ -478,7 +508,7 @@ impl Orchestrator {
 
                 // Send all received topics to the channel so the orchestrator's main thread
                 // can monitor incoming data and iterate accordingly.
-                let _ = tx_msg.send((timestamp, metadata.topic));
+                let _ = tx_msg.send((timestamp, metadata));
 
                 Ok(())
             })
@@ -500,7 +530,7 @@ impl Orchestrator {
                 rx_stop,
                 rx_msg,
                 sim_config,
-                sync_topic_data,
+                tick_group_data,
                 simclock,
                 data_manager,
                 middleware,
@@ -541,16 +571,16 @@ impl Orchestrator {
 impl Orchestrator {
     async fn orchestrator_main(
         rx_stop: Receiver<bool>,
-        rx_msg: Receiver<(TimeStamp, String)>,
+        rx_msg: Receiver<(TimeStamp, Metadata)>,
         sim_config: serde_json::Value,
-        sync_topic_data: Vec<(String, TimeStamp)>,
+        tick_group_data: Vec<(String, Vec<(String, TimeStamp)>)>,
         simclock: Arc<SimClock>,
         data_manager: Arc<DataManager>,
         middleware: Arc<MiddlewareEnum>,
         scene_graph_data_queue: Arc<Mutex<Vec<(TimeStamp, String, SceneGraphStateData)>>>,
     ) {
         info!("Orchestrator main thread started.");
-        let mut sim_time = simclock.sim_time().unwrap_or(TimeStamp::new(0, 0));
+        let mut sim_time: TimeStamp;
         let mut running = true;
 
         let required_renderers: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
@@ -709,8 +739,13 @@ impl Orchestrator {
         {
             let start_time = std::time::Instant::now();
             let timeout_initial_sync_topics = Duration::from_secs(60);
-            let mut sync_topics_set =
-                Orchestrator::get_sync_topics_for_simtime(&sync_topic_data, sim_time);
+            let mut sync_topics_set: HashSet<String> = HashSet::new();
+            for (_clock_topic, sync_topic_data) in &tick_group_data {
+                for (topic, _interval) in sync_topic_data {
+                    // Add all sync_topics for initial sync topic set, regardless of their intervals
+                    sync_topics_set.insert(topic.to_string());
+                }
+            }
             let mut notify_at_sec = 5;
             info!(
                 "Waiting to receive initial sync topics: {:?}",
@@ -756,6 +791,8 @@ impl Orchestrator {
         while running {
             // info!("Orchestrator thread tick.");
             let actual_time_start = tokio::time::Instant::now();
+            debug!("");
+            debug!("Tick start.");
 
             // Step sim clock
             sim_time = simclock.step();
@@ -772,7 +809,6 @@ impl Orchestrator {
                         "sec": now_platform.sec,
                         "nanosec": now_platform.nanosec
                     },
-                    "tick_group": 1  // TODO implement tick groups
                 }));
                 match middleware
                     .publish::<JsonData>("aerosim.clock", &sim_time_json, Some(sim_time))
@@ -788,19 +824,46 @@ impl Orchestrator {
                 );
             }
 
-            // Wait to receive a published message from each of sync_topics before advancing.
+            // Wait for each tick group's sync topics in tick group index order
             {
-                let mut sync_topics_set =
-                    Orchestrator::get_sync_topics_for_simtime(&sync_topic_data, sim_time);
-                // debug!("Waiting to receive sync topics: {:?}", sync_topics_set);
-                while running {
-                    running = Orchestrator::poll_messages(&mut sync_topics_set, &rx_msg, &rx_stop);
-
-                    if sync_topics_set.is_empty() {
-                        break;
+                for (idx, (clock_topic, sync_topic_data)) in tick_group_data.iter().enumerate() {
+                    // Publish this tick group's clock topic
+                    let clock_topic_json = JsonData::new(json!({
+                        "timestamp_sim": {
+                            "sec": sim_time.sec,
+                            "nanosec": sim_time.nanosec
+                        },
+                    }));
+                    match middleware
+                        .publish::<JsonData>(clock_topic, &clock_topic_json, Some(sim_time))
+                        .await
+                    {
+                        Ok(_) => {}
+                        Err(e) => warn!("Could not publish '{}': {:?}", clock_topic, e),
                     }
+                    debug!(
+                        "--- Published tick group index {} clock topic: '{}' ---",
+                        idx, clock_topic
+                    );
+
+                    // Wait to receive a published message from each of sync_topics before advancing.
+                    let mut sync_topics_set =
+                        Orchestrator::get_sync_topics_for_simtime(&sync_topic_data, sim_time);
+
+                    debug!(
+                        "Waiting to receive tick group index {} sync topics: {:?}",
+                        idx, sync_topics_set
+                    );
+                    while running {
+                        running =
+                            Orchestrator::poll_messages(&mut sync_topics_set, &rx_msg, &rx_stop);
+
+                        if sync_topics_set.is_empty() {
+                            break;
+                        }
+                    }
+                    debug!("Received all tick group sync topic messages.");
                 }
-                // debug!("Received all sync topic messages.");
             }
 
             // Update scene graph
@@ -839,16 +902,27 @@ impl Orchestrator {
                 );
             } else if simclock.pace_1x_scale && actual_time_elapsed < simclock.step_size {
                 // Sleep for the remaining actual step time duration
+                // TODO Look into using 'spin_sleep' crate for this
                 let time_to_sleep = simclock.step_size - actual_time_elapsed;
-                // info!(
-                //     "Sleeping for {} ms",
-                //     time_to_sleep.as_millis()
-                // );
+                // debug!("Sleeping for {} ms", time_to_sleep.as_millis());
                 let wait_time = std::time::SystemTime::now();
                 while wait_time.elapsed().unwrap() < time_to_sleep {
-                    tokio::time::sleep(Duration::ZERO).await; // on Windows, sleep() for >0 is not accurate
+                    // Yield instead of sleeping since even sleep(zero) can take
+                    // multiple milliseconds on Windows
+                    tokio::task::yield_now().await;
                 }
+                // debug!(
+                //     "Sleep actual-target: {} ms",
+                //     wait_time.elapsed().unwrap().as_millis() - time_to_sleep.as_millis()
+                // );
             }
+
+            let total_tick_time_ms = actual_time_start.elapsed().as_micros() as f64 / 1000.0;
+            debug!(
+                "Tick end: processing time = {:.1} ms, total time = {:.1} ms",
+                actual_time_elapsed.as_secs_f64() * 1000.0,
+                total_tick_time_ms
+            );
         } // end of main running loop
 
         // Orchestrator main thread is stopping
@@ -903,7 +977,7 @@ impl Orchestrator {
 
     fn poll_messages(
         sync_topics: &mut HashSet<String>,
-        rx_msg: &Receiver<(TimeStamp, String)>,
+        rx_msg: &Receiver<(TimeStamp, Metadata)>,
         rx_stop: &Receiver<bool>,
     ) -> bool {
         let mut keep_running = true;
@@ -915,10 +989,16 @@ impl Orchestrator {
         match rx_msg.try_recv() {
             Ok(msg) => {
                 let _timestamp = msg.0;
-                let topic = msg.1;
+                let metadata = msg.1;
 
                 // Process sync topics
-                let _was_removed = sync_topics.remove(&topic);
+                let was_removed = sync_topics.remove(&metadata.topic);
+                if was_removed {
+                    debug!(
+                        "Received sync topic: '{}' with timestamp_sim: {:?}",
+                        metadata.topic, metadata.timestamp_sim
+                    );
+                }
             }
             Err(TryRecvError::Disconnected) => {
                 keep_running = false;

--- a/examples/config/sim_config_autopilot_daa_scenario.json
+++ b/examples/config/sim_config_autopilot_daa_scenario.json
@@ -14,6 +14,19 @@
                         "interval_ms": 20
                     },
                     {
+                        "topic": "aerosim.actor1.primary_flight_display_data",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.intruder1.vehicle_state",
+                        "interval_ms": 20
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_02",
+                "sync_topics": [
+                    {
                         "topic": "aerosim.actor1.tiltrotor_1.effector_state",
                         "interval_ms": 20
                     },
@@ -59,14 +72,6 @@
                     },
                     {
                         "topic": "aerosim.actor1.rotor_6.effector_state",
-                        "interval_ms": 20
-                    },
-                    {
-                        "topic": "aerosim.actor1.primary_flight_display_data",
-                        "interval_ms": 20
-                    },
-                    {
-                        "topic": "aerosim.intruder1.vehicle_state",
                         "interval_ms": 20
                     },
                     {
@@ -1482,7 +1487,7 @@
             "fmu_model_path": "examples/fmu/evtol_effectors_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [],
             "component_output_topics": [
@@ -1607,7 +1612,7 @@
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [],
             "component_output_topics": [

--- a/examples/config/sim_config_autopilot_daa_scenario.json
+++ b/examples/config/sim_config_autopilot_daa_scenario.json
@@ -5,70 +5,75 @@
         "pace_1x_scale": true
     },
     "orchestrator": {
-        "sync_topics": [
+        "tick_groups": [
             {
-                "topic": "aerosim.actor1.vehicle_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.tiltrotor_1.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.tiltrotor_2.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.tiltrotor_3.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.tiltrotor_4.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.tiltrotor_5.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.tiltrotor_6.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.rotor_1.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.rotor_2.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.rotor_3.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.rotor_4.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.rotor_5.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.rotor_6.effector_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.primary_flight_display_data",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.intruder1.vehicle_state",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.intruder1.propeller.effector_state",
-                "interval_ms": 20
+                "clock_topic": "aerosim.clock.tick_group_01",
+                "sync_topics": [
+                    {
+                        "topic": "aerosim.actor1.vehicle_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.tiltrotor_1.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.tiltrotor_2.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.tiltrotor_3.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.tiltrotor_4.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.tiltrotor_5.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.tiltrotor_6.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.rotor_1.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.rotor_2.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.rotor_3.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.rotor_4.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.rotor_5.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.rotor_6.effector_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.primary_flight_display_data",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.intruder1.vehicle_state",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.intruder1.propeller.effector_state",
+                        "interval_ms": 20
+                    }
+                ]
             }
         ]
     },
@@ -520,7 +525,10 @@
         {
             "id": "evtol_vehicle",
             "fmu_model_path": "examples/fmu/evtol_vehicle_fmu.fmu",
-            "component_type": "dynamics_model",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -1472,7 +1480,10 @@
         {
             "id": "evtol_effectors",
             "fmu_model_path": "examples/fmu/evtol_effectors_fmu_model.fmu",
-            "component_type": "dynamics_model",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -1562,6 +1573,10 @@
         {
             "id": "trajectory_follower_intruder1",
             "fmu_model_path": "examples/fmu/trajectory_follower_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -1590,6 +1605,10 @@
         {
             "id": "propeller_effector_intruder1",
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {

--- a/examples/config/sim_config_pilot_control_with_flight_deck_ap.json
+++ b/examples/config/sim_config_pilot_control_with_flight_deck_ap.json
@@ -5,18 +5,23 @@
         "pace_1x_scale": true
     },
     "orchestrator": {
-        "sync_topics": [
+        "tick_groups": [
             {
-                "topic": "aerosim.actor1.flight_control_command",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.aircraft_effector_command",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.vehicle_state",
-                "interval_ms": 20
+                "clock_topic": "aerosim.clock.tick_group_01",
+                "sync_topics": [
+                    {
+                        "topic": "aerosim.actor1.flight_control_command",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.aircraft_effector_command",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.vehicle_state",
+                        "interval_ms": 20
+                    }
+                ]
             }
         ],
         "output_sim_data_file": "simdata_pilot_control_with_flight_deck.mcap"
@@ -174,6 +179,10 @@
         {
             "id": "autopilot_controller",
             "fmu_model_path": "examples/fmu/jsbsim_autopilot_controller_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [
                 {
                     "msg_type": "aerosim::types::AutopilotCommand",
@@ -219,6 +228,10 @@
         {
             "id": "flight_controller",
             "fmu_model_path": "examples/fmu/jsbsim_flight_controller_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [
                 {
                     "msg_type": "aerosim::types::FlightControlCommand",
@@ -245,6 +258,10 @@
         {
             "id": "dynamics_model",
             "fmu_model_path": "examples/fmu/jsbsim_dynamics_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [
                 {
                     "msg_type": "aerosim::types::AircraftEffectorCommand",
@@ -287,6 +304,10 @@
         {
             "id": "primary_flight_display",
             "fmu_model_path": "examples/fmu/primary_flight_display_controller_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -323,6 +344,10 @@
         {
             "id": "propeller_effector",
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {

--- a/examples/config/sim_config_pilot_control_with_flight_deck_ap.json
+++ b/examples/config/sim_config_pilot_control_with_flight_deck_ap.json
@@ -12,13 +12,36 @@
                     {
                         "topic": "aerosim.actor1.flight_control_command",
                         "interval_ms": 20
-                    },
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_02",
+                "sync_topics": [
                     {
                         "topic": "aerosim.actor1.aircraft_effector_command",
                         "interval_ms": 20
-                    },
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_03",
+                "sync_topics": [
                     {
                         "topic": "aerosim.actor1.vehicle_state",
+                        "interval_ms": 20
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_04",
+                "sync_topics": [
+                    {
+                        "topic": "aerosim.actor1.primary_flight_display_data",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.propeller.effector_state",
                         "interval_ms": 20
                     }
                 ]
@@ -230,7 +253,7 @@
             "fmu_model_path": "examples/fmu/jsbsim_flight_controller_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [
                 {
@@ -260,7 +283,7 @@
             "fmu_model_path": "examples/fmu/jsbsim_dynamics_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_03"
             },
             "component_input_topics": [
                 {
@@ -306,7 +329,7 @@
             "fmu_model_path": "examples/fmu/primary_flight_display_controller_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_04"
             },
             "component_input_topics": [],
             "component_output_topics": [
@@ -346,7 +369,7 @@
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_04"
             },
             "component_input_topics": [],
             "component_output_topics": [

--- a/examples/config/sim_config_pilot_control_with_flight_deck_fc.json
+++ b/examples/config/sim_config_pilot_control_with_flight_deck_fc.json
@@ -12,9 +12,27 @@
                     {
                         "topic": "aerosim.actor1.aircraft_effector_command",
                         "interval_ms": 20
-                    },
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_02",
+                "sync_topics": [
                     {
                         "topic": "aerosim.actor1.vehicle_state",
+                        "interval_ms": 20
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_03",
+                "sync_topics": [
+                    {
+                        "topic": "aerosim.actor1.primary_flight_display_data",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.propeller.effector_state",
                         "interval_ms": 20
                     }
                 ]
@@ -207,7 +225,7 @@
             "fmu_model_path": "examples/fmu/jsbsim_dynamics_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [
                 {
@@ -249,7 +267,7 @@
             "fmu_model_path": "examples/fmu/primary_flight_display_controller_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_03"
             },
             "component_input_topics": [],
             "component_output_topics": [
@@ -283,7 +301,7 @@
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_03"
             },
             "component_input_topics": [],
             "component_output_topics": [

--- a/examples/config/sim_config_pilot_control_with_flight_deck_fc.json
+++ b/examples/config/sim_config_pilot_control_with_flight_deck_fc.json
@@ -5,14 +5,19 @@
         "pace_1x_scale": true
     },
     "orchestrator": {
-        "sync_topics": [
+        "tick_groups": [
             {
-                "topic": "aerosim.actor1.aircraft_effector_command",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.vehicle_state",
-                "interval_ms": 20
+                "clock_topic": "aerosim.clock.tick_group_01",
+                "sync_topics": [
+                    {
+                        "topic": "aerosim.actor1.aircraft_effector_command",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.vehicle_state",
+                        "interval_ms": 20
+                    }
+                ]
             }
         ],
         "output_sim_data_file": "simdata_pilot_control_with_flight_deck.mcap"
@@ -170,6 +175,10 @@
         {
             "id": "flight_controller",
             "fmu_model_path": "examples/fmu/jsbsim_flight_controller_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [
                 {
                     "msg_type": "aerosim::types::FlightControlCommand",
@@ -196,6 +205,10 @@
         {
             "id": "dynamics_model",
             "fmu_model_path": "examples/fmu/jsbsim_dynamics_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [
                 {
                     "msg_type": "aerosim::types::AircraftEffectorCommand",
@@ -234,6 +247,10 @@
         {
             "id": "primary_flight_display",
             "fmu_model_path": "examples/fmu/primary_flight_display_controller_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -264,6 +281,10 @@
         {
             "id": "propeller_effector",
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {

--- a/examples/config/sim_config_simulink_cosim_and_fmu.json
+++ b/examples/config/sim_config_simulink_cosim_and_fmu.json
@@ -5,14 +5,19 @@
         "pace_1x_scale": true
     },
     "orchestrator": {
-        "sync_topics": [
+        "tick_groups": [
             {
-                "topic": "aerosim.simulink_out",
-                "interval_ms": 20
-            },
-            {
-                "topic": "aerosim.actor1.vehicle_state",
-                "interval_ms": 20
+                "clock_topic": "aerosim.clock.tick_group_01",
+                "sync_topics": [
+                    {
+                        "topic": "aerosim.simulink_out",
+                        "interval_ms": 20
+                    },
+                    {
+                        "topic": "aerosim.actor1.vehicle_state",
+                        "interval_ms": 20
+                    }
+                ]
             }
         ]
     },
@@ -156,6 +161,10 @@
         {
             "id": "1DOF_dynamics",
             "fmu_model_path": "examples/fmu/aerosim_simulink_fmu_1DOF_dynamics.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -176,6 +185,10 @@
         {
             "id": "main_rotor_effector",
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {
@@ -199,6 +212,10 @@
         {
             "id": "tail_rotor_effector",
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
+            "step_trigger_topic": {
+                "msg_type": "aerosim::types::JsonData",
+                "topic": "aerosim.clock.tick_group_01"
+            },
             "component_input_topics": [],
             "component_output_topics": [
                 {

--- a/examples/config/sim_config_simulink_cosim_and_fmu.json
+++ b/examples/config/sim_config_simulink_cosim_and_fmu.json
@@ -12,7 +12,12 @@
                     {
                         "topic": "aerosim.simulink_out",
                         "interval_ms": 20
-                    },
+                    }
+                ]
+            },
+            {
+                "clock_topic": "aerosim.clock.tick_group_02",
+                "sync_topics": [
                     {
                         "topic": "aerosim.actor1.vehicle_state",
                         "interval_ms": 20
@@ -163,7 +168,7 @@
             "fmu_model_path": "examples/fmu/aerosim_simulink_fmu_1DOF_dynamics.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [],
             "component_output_topics": [
@@ -187,7 +192,7 @@
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [],
             "component_output_topics": [
@@ -214,7 +219,7 @@
             "fmu_model_path": "examples/fmu/rotor_effector_fmu_model.fmu",
             "step_trigger_topic": {
                 "msg_type": "aerosim::types::JsonData",
-                "topic": "aerosim.clock.tick_group_01"
+                "topic": "aerosim.clock.tick_group_02"
             },
             "component_input_topics": [],
             "component_output_topics": [


### PR DESCRIPTION
Implement FMU execution sequencing using configurable tick groups and step trigger topics.

- Add rounding helper functions for handling timestamps as float seconds with microsec precision.
- Update Python FMU driver to use the configured `step_trigger_topic` to trigger its steps, and improve handling of variable types and time step precision.
- Update Rust FMU driver to use the configured `step_trigger_topic` to trigger its steps, and refactor to clean up the FMU utilities.
- Update Orchestrator to publish clock topics for tick groups and wait for the sync topics within each tick group before doing the next one, and also improve the loop sleep timing precision.
- Update sim configs to add orchestrator `tick_groups` and FMU `step_trigger_topic`.