### PR TITLE
Add ability to select middleware_type in sim config

### DIFF
--- a/aerosim-core/Cargo.toml
+++ b/aerosim-core/Cargo.toml
@@ -11,7 +11,7 @@ name = "aerosim_core"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-aerosim-data = { path = "../aerosim-data" }
+aerosim-data = { path = "../aerosim-data", default-features = false }
 chrono.workspace = true
 log.workspace = true
 pyo3.workspace = true

--- a/aerosim-data/Cargo.toml
+++ b/aerosim-data/Cargo.toml
@@ -30,7 +30,7 @@ serde_repr = "0.1.20"
 turbojpeg = { version = "1.3.0", default-features = false, features = ["cmake"] }
 
 [features]
-default = ["zenoh"]
+default = ["kafka", "zenoh"]
 middleware = ["r2r", "dds", "kafka", "zenoh"]
 
 dds = ["cyclors", "cdr"]

--- a/aerosim-data/src/middleware/mod.rs
+++ b/aerosim-data/src/middleware/mod.rs
@@ -15,29 +15,35 @@ use serde::{Deserialize, Serialize};
 use crate::types::{AerosimMessage, PyTypeSupport, TimeStamp, TypeRegistry};
 
 pub mod common;
+pub mod no_middleware;
 pub mod serializers;
-
-#[cfg(feature = "dds")]
-pub mod dds;
-#[cfg(feature = "kafka")]
-pub mod kafka;
-#[cfg(feature = "zenoh")]
-pub mod zenoh;
 
 use common::message;
 pub use common::{Message, Metadata};
 
+use crate::middleware::no_middleware::{NoMiddleware, NoSerializer};
 pub use aerosim_macros::AerosimDeserializeEnum;
 pub use serializers::bincode::BincodeSerializer;
 
 #[cfg(feature = "dds")]
+pub mod dds;
+#[cfg(feature = "dds")]
 pub use dds::{DDSMiddleware, DDSSerializer};
+
+#[cfg(feature = "kafka")]
+pub mod kafka;
 #[cfg(feature = "kafka")]
 pub use kafka::{KafkaMiddleware, KafkaSerializer};
+
+#[cfg(feature = "zenoh")]
+pub mod zenoh;
 #[cfg(feature = "zenoh")]
 pub use zenoh::{ZenohMiddleware, ZenohSerializer};
 
+// CallbackClosureRaw can be created as: Box::new(move |payload: &[u8]| { ... })
 pub type CallbackClosureRaw = Box<dyn Fn(&[u8]) -> Result<(), Box<dyn Error>> + Send + Sync>;
+
+// CallbackClosure can be created as: Box::new(move |data, metadata| { ... })
 pub type CallbackClosure<T> = Box<dyn Fn(T, Metadata) -> Result<(), Box<dyn Error>> + Send + Sync>;
 
 #[enum_dispatch(SerializerEnum)]
@@ -172,23 +178,36 @@ pub trait PySerializer: Serializer {
 #[async_trait]
 #[enum_dispatch(MiddlewareEnum)]
 pub trait MiddlewareRaw: Send + Sync {
+    // Publish data of any type as a raw [u8] byte array with the
+    // message_type specified as a string
     async fn publish_raw(
         &self,
         message_type: &str,
         topic: &str,
         payload: &[u8],
     ) -> Result<(), Box<dyn Error>>;
+
+    // Subscribe to data of any type with a single callback to process it
+    // as a raw [u8] byte array payload that can be deserialized based on
+    // the message_type string by using the transport's serializer.
     async fn subscribe_raw(
         &self,
         message_type: &str,
         topic: &str,
         callback: CallbackClosureRaw,
     ) -> Result<(), Box<dyn Error>>;
+
+    // Subscribe to multiple topics of any types with a single callback to
+    // process them as raw [u8] byte array payloads that can be deserialized
+    // based on their message_type string for each topic by using the
+    // transport's serializer.
     async fn subscribe_all_raw(
         &self,
         topics: Vec<(String, String)>,
         callback: CallbackClosureRaw,
     ) -> Result<(), Box<dyn Error>>;
+
+    // TODO Implement graceful shutdown of middleware connections
     fn shutdown_raw(&self) {}
 }
 
@@ -197,6 +216,9 @@ pub trait MiddlewareRaw: Send + Sync {
 pub trait Middleware: MiddlewareRaw {
     fn get_serializer(&self) -> SerializerEnum;
 
+    // Publish a concrete data type message, ex. publish::<JsonData>() with an
+    // optionally provided sim timestamp. If timestamp_sim is None, then it
+    // will be set as SENTINAL_SECONDS in the message metadata.
     async fn publish<T: AerosimMessage + 'static>(
         &self,
         topic: &str,
@@ -219,6 +241,8 @@ pub trait Middleware: MiddlewareRaw {
         self.publish_raw(&T::get_type_name(), topic, &payload).await
     }
 
+    // Subscribe to a concrete data type message, ex. subscribe::<JsonData>() with
+    // a callback to process the deserialized data of that type.
     async fn subscribe<T: AerosimMessage + 'static>(
         &self,
         topic: &str,
@@ -236,6 +260,8 @@ pub trait Middleware: MiddlewareRaw {
             .await
     }
 
+    // Subscribe to multiple messages of the same concrete data type, ex. subscribe_all::<JsonData>()
+    // with a common callback to process the deserialized data for each topic.
     async fn subscribe_all<T: AerosimMessage + 'static>(
         &self,
         topics: Vec<String>,
@@ -436,6 +462,7 @@ trait PyMiddleware: Middleware {
 
 #[enum_dispatch]
 pub enum MiddlewareEnum {
+    NoMiddleware,
     #[cfg(feature = "dds")]
     DDSMiddleware,
     #[cfg(feature = "kafka")]
@@ -446,6 +473,7 @@ pub enum MiddlewareEnum {
 
 #[enum_dispatch]
 pub enum SerializerEnum {
+    NoSerializer,
     BincodeSerializer,
     #[cfg(feature = "dds")]
     DDSSerializer,

--- a/aerosim-data/src/middleware/no_middleware.rs
+++ b/aerosim-data/src/middleware/no_middleware.rs
@@ -1,0 +1,68 @@
+use crate::middleware::{
+    CallbackClosureRaw, Middleware, MiddlewareRaw, PyMiddleware, Serializer, SerializerEnum,
+};
+use async_trait::async_trait;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+
+//Dummy middleware/serializer types to allow this crate to be built without any
+// middleware dependencies for crates that only need the data types by importing
+// with 'default-features = false'
+#[pyclass]
+pub struct NoMiddleware {}
+
+#[async_trait]
+impl MiddlewareRaw for NoMiddleware {
+    async fn publish_raw(
+        &self,
+        _message_type: &str,
+        _topic: &str,
+        _payload: &[u8],
+    ) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+
+    async fn subscribe_raw(
+        &self,
+        _message_type: &str,
+        _topic: &str,
+        _callback: CallbackClosureRaw,
+    ) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+
+    async fn subscribe_all_raw(
+        &self,
+        _topics: Vec<(String, String)>,
+        _callback: CallbackClosureRaw,
+    ) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+}
+
+impl PyMiddleware for NoMiddleware {}
+
+#[async_trait]
+impl Middleware for NoMiddleware {
+    fn get_serializer(&self) -> SerializerEnum {
+        SerializerEnum::from(NoSerializer {})
+    }
+}
+
+#[pyclass]
+pub struct NoSerializer;
+
+impl Serializer for NoSerializer {
+    fn serializer(&self) -> SerializerEnum {
+        SerializerEnum::from(Self {})
+    }
+
+    fn serialize<T: Serialize>(&self, _data: &T) -> Option<Vec<u8>> {
+        None
+    }
+
+    fn deserialize<T: for<'de> Deserialize<'de>>(&self, _payload: &[u8]) -> Option<T> {
+        None
+    }
+}

--- a/aerosim-scenarios/Cargo.toml
+++ b/aerosim-scenarios/Cargo.toml
@@ -11,7 +11,7 @@ name = "aerosim_scenarios"
 crate-type = ["cdylib"]
 
 [dependencies]
-aerosim-data = { path = "../aerosim-data", features = ["zenoh"] }
+aerosim-data = { path = "../aerosim-data", default-features = false }
 pyo3.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/aerosim-sensors/Cargo.toml
+++ b/aerosim-sensors/Cargo.toml
@@ -11,7 +11,7 @@ name = "aerosim_sensors"
 crate-type = ["cdylib"]
 
 [dependencies]
-aerosim-data = { path = "../aerosim-data", features = ["zenoh"] }
+aerosim-data = { path = "../aerosim-data", default-features = false }
 pyo3.workspace = true
 adsb_deku = "0.7.1"
 hex = "0.4.3"

--- a/aerosim-world-link/Cargo.lock
+++ b/aerosim-world-link/Cargo.lock
@@ -43,8 +43,10 @@ dependencies = [
  "ctor",
  "enum_dispatch",
  "futures",
+ "futures-util",
  "pyo3",
  "pythonize",
+ "rdkafka",
  "schemars 0.8.22",
  "serde",
  "serde_bytes",
@@ -1429,6 +1431,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1702,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,6 +1960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "pnet_base"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2205,6 +2256,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16c17f411935214a5870e40aff9291f8b40a73e97bf8de29e5959c473d5ef33"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.9.0+2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230dca48bc354d718269f3e4353280e188b610f7af7e2fcf54b7a79d5802872"
+dependencies = [
+ "cmake",
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3489,6 +3571,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/aerosim-world-link/Cargo.toml
+++ b/aerosim-world-link/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aerosim-core = { path = "../aerosim-core" }
-aerosim-data = { path = "../aerosim-data", features = ["zenoh"] }
+aerosim-data = { path = "../aerosim-data" }
 futures = "0.3.31"
 lazy_static = "1.5.0"
 log = "0.4.25"

--- a/aerosim-world-link/src/lib.rs
+++ b/aerosim-world-link/src/lib.rs
@@ -60,15 +60,28 @@ pub extern "C" fn initialize_logger(log_file: *const c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn initialize_message_handler(instance_id: *const c_char) -> bool {
+pub extern "C" fn initialize_message_handler(
+    instance_id: *const c_char,
+    middleware_type: *const c_char,
+) -> bool {
     info!("[aerosim.renderer] Initializing message handler.");
 
     // Convert the C string (instance_id) to a Rust string
-    let c_str = unsafe {
+    let instance_id_c_str = unsafe {
         assert!(!instance_id.is_null());
         CStr::from_ptr(instance_id)
     };
-    let instance_id_str = c_str.to_str().unwrap();
+    let instance_id_str = instance_id_c_str
+        .to_str()
+        .expect("Failed to convert instance_id C string to Rust string.");
+
+    let middleware_c_str = unsafe {
+        assert!(!middleware_type.is_null());
+        CStr::from_ptr(middleware_type)
+    };
+    let middleware_type_str = middleware_c_str
+        .to_str()
+        .expect("Failed to convert middleware_type C string to Rust string.");
 
     let mut handler = match GLOBAL_HANDLER.lock() {
         Ok(handler) => handler,
@@ -86,7 +99,7 @@ pub extern "C" fn initialize_message_handler(instance_id: *const c_char) -> bool
     }
 
     info!("[aerosim.renderer] Creating a new MessageHandler.");
-    *handler = Some(MessageHandler::new(instance_id_str));
+    *handler = Some(MessageHandler::new(instance_id_str, middleware_type_str));
 
     true
 }
@@ -203,7 +216,7 @@ pub extern "C" fn publish_image_to_topic(
         ),
         height: height as u32,
         width: width as u32,
-        encoding,  // Hardcoded to BGRA on the renderer side.
+        encoding, // Hardcoded to BGRA on the renderer side.
         is_bigendian: 0,
         step: (width * 4) as u32, // Assuming there is no padding
         data: Cow::Borrowed(image_data),

--- a/aerosim-world-link/src/message_handler.rs
+++ b/aerosim-world-link/src/message_handler.rs
@@ -120,17 +120,32 @@ pub struct MessageHandler {
 }
 
 impl MessageHandler {
-    pub fn new(renderer_id: &str) -> Self {
+    pub fn new(renderer_id: &str, middleware_type: &str) -> Self {
         info!("[aerosim.renderer.message_handler] Creating a new MessageHandler.");
 
         let (tx_stop, rx_stop) = tokio::sync::mpsc::channel::<bool>(1);
         let (tx_img, rx_img) = tokio::sync::mpsc::channel::<(String, Image)>(1);
 
+        let transport = match middleware_type {
+            "kafka" => MiddlewareRegistry::new()
+                .get("kafka")
+                .expect("Failed to get Kafka middleware."),
+            "zenoh" => MiddlewareRegistry::new()
+                .get("zenoh")
+                .expect("Failed to get Zenoh middleware."),
+            _ => {
+                warn!("[aerosim.renderer.message_handler] Invalid middleware type: {}. Using 'zenoh' as default.", middleware_type);
+                MiddlewareRegistry::new()
+                    .get("zenoh")
+                    .expect("Failed to get Zenoh middleware.")
+            }
+        };
+
         MessageHandler {
             renderer_id: renderer_id.to_string(),
             _sim_config: serde_json::Value::Null,
             runtime: Arc::new(tokio::runtime::Runtime::new().unwrap()),
-            transport: MiddlewareRegistry::new().get("zenoh").unwrap(),
+            transport: transport,
             payload_queue: Arc::new(Mutex::new(PayloadQueue::new())),
             assigned_sensors: Arc::new(Mutex::new(HashSet::new())),
             thread_handle: None,

--- a/aerosim-world/Cargo.toml
+++ b/aerosim-world/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 aerosim-core = { path = "../aerosim-core" }
-aerosim-data = { path = "../aerosim-data", features = ["zenoh"] }
+aerosim-data = { path = "../aerosim-data" }
 chrono.workspace = true
 log.workspace = true
 log4rs.workspace = true

--- a/aerosim-world/python/aerosim_world/pyfmu_driver.py
+++ b/aerosim-world/python/aerosim_world/pyfmu_driver.py
@@ -34,7 +34,16 @@ class PyFmuDriver:
         self._running = True
         self._processing_callback_lock = threading.Lock()
 
-        self.transport = middleware.get_transport("zenoh")
+        valid_middleware = ["kafka", "zenoh"]
+        if middleware_type not in valid_middleware:
+            print(
+                f"{self.fmudriver_name} WARNING: Invalid 'middleware' parameter: {middleware_type}. Using default type as 'zenoh'."
+            )
+            middleware_type = "zenoh"
+
+        self.transport = middleware.get_transport(middleware_type)
+        print(f"{self.fmudriver_name} Loaded {middleware_type} middleware.")
+
         self.serializer = self.transport.get_serializer()
 
         self.transport.subscribe(

--- a/aerosim-world/src/orchestrator.rs
+++ b/aerosim-world/src/orchestrator.rs
@@ -145,11 +145,25 @@ impl Orchestrator {
         }
 
         // Load middleware
-        self.middleware = MiddlewareRegistry::new().get("zenoh");
+        let middleware_type = match self.sim_config["middleware_type"].as_str() {
+            Some("kafka") => "kafka",
+            Some("zenoh") => "zenoh",
+            Some(&_) => {
+                warn!("Invalid 'middleware_type' in config. Using default 'zenoh'.");
+                "zenoh"
+            }
+            None => {
+                warn!("No 'middleware_type' found in config. Using default 'zenoh'.");
+                "zenoh"
+            }
+        };
+
+        self.middleware = MiddlewareRegistry::new().get(middleware_type);
         let middleware = self
             .middleware
             .as_ref()
             .expect("Couldn't initialize middleware");
+        info!("Loaded {} middleware.", middleware_type);
 
         // Set up set of required renderers and subscribe to renderer status topic to
         // wait for acknowledgement of renderer readiness before finishing load command

--- a/aerosim/src/aerosim/core/simulation.py
+++ b/aerosim/src/aerosim/core/simulation.py
@@ -37,7 +37,7 @@ class AeroSim:
         self.websocket_tasks = []
         self.is_sim_started = False
         self.simclock_msg = None
-        self.transport = middleware.get_transport("zenoh")
+        self.transport = None
 
     def run(
         self,
@@ -59,6 +59,25 @@ class AeroSim:
         print(f"Loading simulation configuration from {sim_config_path}...")
         with open(sim_config_path, "r") as file:
             self.sim_config_json = json.load(file)
+
+        # ----------------------------------------------
+        # Set up middleware transport
+        valid_middleware = ["kafka", "zenoh"]
+        if "middleware_type" not in self.sim_config_json:
+            print(
+                "WARNING: Couldn't find 'middleware_type' in sim config. Using default type as 'zenoh'."
+            )
+            middleware_type = "zenoh"
+        elif self.sim_config_json["middleware_type"] not in valid_middleware:
+            print(
+                f"WARNING: Invalid 'middleware_type' value in config: {self.sim_config_json['middleware_type']}. Using default type as 'zenoh'."
+            )
+            middleware_type = "zenoh"
+        else:
+            middleware_type = self.sim_config_json["middleware_type"]
+
+        self.transport = middleware.get_transport(middleware_type)
+        print(f"Loaded {middleware_type} middleware.")
 
         # ----------------------------------------------
         # Initialize AeroSim components
@@ -87,11 +106,15 @@ class AeroSim:
             print(f"Initializing AeroSim FMU Driver '{fmu_config['id']}'...")
             if fmu_driver_type == "python":
                 self.aerosim_fmudrivers.append(
-                    aerosim_world.PyFmuDriver(fmu_config["id"], sim_config_dir, "zenoh")
+                    aerosim_world.PyFmuDriver(
+                        fmu_config["id"], sim_config_dir, middleware_type
+                    )
                 )
             else:
                 self.aerosim_fmudrivers.append(
-                    aerosim_world.FmuDriver(fmu_config["id"], sim_config_dir, "zenoh")
+                    aerosim_world.FmuDriver(
+                        fmu_config["id"], sim_config_dir, middleware_type
+                    )
                 )
 
         # ----------------------------------------------

--- a/examples/config/sim_config_autopilot_daa_scenario.json
+++ b/examples/config/sim_config_autopilot_daa_scenario.json
@@ -1,5 +1,6 @@
 {
     "description": "Detect and Avoid Scenario.",
+    "middleware_type": "zenoh",
     "clock": {
         "step_size_ms": 20,
         "pace_1x_scale": true

--- a/examples/config/sim_config_pilot_control_with_flight_deck_ap.json
+++ b/examples/config/sim_config_pilot_control_with_flight_deck_ap.json
@@ -1,5 +1,6 @@
 {
     "description": "Example of human pilot-in-the-loop simulation of flying an airplane with manual keyboard/joystick controls.",
+    "middleware_type": "zenoh",
     "clock": {
         "step_size_ms": 20,
         "pace_1x_scale": true

--- a/examples/config/sim_config_pilot_control_with_flight_deck_fc.json
+++ b/examples/config/sim_config_pilot_control_with_flight_deck_fc.json
@@ -1,5 +1,6 @@
 {
     "description": "Example of human pilot-in-the-loop simulation of flying an airplane with manual keyboard/joystick controls.",
+    "middleware_type": "zenoh",
     "clock": {
         "step_size_ms": 20,
         "pace_1x_scale": true

--- a/examples/config/sim_config_simulink_cosim_and_fmu.json
+++ b/examples/config/sim_config_simulink_cosim_and_fmu.json
@@ -1,5 +1,6 @@
 {
     "description": "Simulink co-simulation controller model with a simple 1DOF dynamics model FMU that was exported from another Simulink model.",
+    "middleware_type": "zenoh",
     "clock": {
         "step_size_ms": 20,
         "pace_1x_scale": true


### PR DESCRIPTION
- [x] Update `aerosim-data` to include both kafka and zenoh middleware types by default.
- [x] Add a dummy `NoMiddleware/NoSerializer` options in `aerosim-data` to allow it to be referenced with `default-features = false` in crates that don't need to use any middleware.
- [x] Add `middleware_type` parameter to aerosim-world-link's `initialize_message_handler()` function and `MessageHandler` to choose middleware at runtime.
- [x] Update `PyFmuDriver` constructor to initialize the specified middleware parameter's type.
- [x] Update `Orchestrator::load()` function and the Python class `AeroSim::run()` function to initialize the middleware type specified from the sim config JSON.
- [x] Update the example sim config JSON files to specify zenoh as the middleware type.