### PR TITLE
Fix FMU Driver shutdown hang by ensuring Zenoh stop command delivery

### DIFF
--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -67,6 +67,7 @@ impl MiddlewareRaw for ZenohMiddleware {
 
         session
             .put(topic, payload)
+            .congestion_control(zenoh::qos::CongestionControl::Block)
             .await
             .expect("Failed to publish message");
 

--- a/aerosim-world/src/fmu_driver.rs
+++ b/aerosim-world/src/fmu_driver.rs
@@ -120,7 +120,7 @@ impl FmuDriver {
                         middleware.clone(),
                         &fmu_id,
                         &working_dir,
-                    ))
+                    ));
                 })
                 .expect("Unable to spawn FMU Driver thread"),
         );
@@ -134,29 +134,34 @@ impl FmuDriver {
     }
 
     fn stop(&mut self) {
-        info!("[{}] Stopping FMU Driver thread.", self.fmu_id);
+        info!("[{}] Stopping FMU Driver.", self.fmu_id);
 
-        // Stop thread
-        match self.fmu_driver_thread_tx_stop.take() {
-            Some(tx_stop) => match tx_stop.send(true) {
-                Ok(_) => {}
-                Err(e) => {
-                    warn!("Could not send stop flag to FMU Driver thread: {:?}", e);
+        // Send stop flag to thread (may fail if thread already exited via orchestrator command)
+        if let Some(tx_stop) = self.fmu_driver_thread_tx_stop.take() {
+            let _ = tx_stop.send(true);
+        }
+
+        // Wait for thread to finish
+        if let Some(handle) = self.fmu_driver_thread_handle.take() {
+            let start = std::time::Instant::now();
+            loop {
+                if handle.is_finished() {
+                    let _ = handle.join();
+                    break;
                 }
-            },
-            None => {
-                return;
+                if start.elapsed().as_secs() >= 30 {
+                    error!(
+                        "[{}] Thread join timed out after 30s - abandoning join!",
+                        self.fmu_id
+                    );
+                    std::mem::forget(handle);
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
             }
         }
 
-        let handle = self
-            .fmu_driver_thread_handle
-            .take()
-            .expect("No FMU Driver thread handle, was it started?");
-
-        handle
-            .join()
-            .expect("Thread should have stopped after receiving stop flag.");
+        info!("[{}] FMU Driver stopped.", self.fmu_id);
     }
 }
 

--- a/aerosim-world/src/orchestrator.rs
+++ b/aerosim-world/src/orchestrator.rs
@@ -955,9 +955,11 @@ impl Orchestrator {
             )
             .await
         {
-            Ok(_) => {}
+            Ok(_) => {
+                info!("Published stop command.");
+            }
             Err(e) => warn!(
-                "Could not pusblish `aerosim.orchestrator.commands`: {:?}",
+                "Could not publish `aerosim.orchestrator.commands`: {:?}",
                 e
             ),
         };

--- a/aerosim/src/aerosim/core/simulation.py
+++ b/aerosim/src/aerosim/core/simulation.py
@@ -191,6 +191,10 @@ class AeroSim:
         if self.aerosim_orchestrator:
             self.aerosim_orchestrator.stop()
 
+        # Brief delay for the orchestrator's stop command to be delivered and processed
+        # by all FMU drivers via Zenoh before calling stop() on each driver.
+        time.sleep(0.5)
+
         for fmu_driver in self.aerosim_fmudrivers:
             fmu_driver.stop()
 


### PR DESCRIPTION
The simulation was hanging during shutdown because FMU Driver threads were not receiving the orchestrator's stop command via Zenoh before the orchestrator exited. This was a race condition in async message delivery.

Changes:
- Add CongestionControl::Block to Zenoh publish_raw() for deterministic message transmission before the publish call returns
- Add brief delay in Python simulation.stop() to allow FMU drivers to process the stop command before calling stop() on each driver
- Improve FMU Driver stop() to handle threads that already exited via the orchestrator command, with a 30s timeout safeguard