### PR TITLE
Fix FATAL exception on shutdown by adding ZenohMiddleware cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "futures-util",
+ "log",
  "pyo3",
  "pythonize",
  "r2r",

--- a/aerosim-data/Cargo.toml
+++ b/aerosim-data/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 aerosim-macros = { path = "../aerosim-macros" }
 chrono.workspace = true
+log.workspace = true
 pyo3.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/aerosim-data/python/aerosim_data/middleware.py
+++ b/aerosim-data/python/aerosim_data/middleware.py
@@ -32,6 +32,15 @@ class BaseMiddleware(metaclass=Singleton):
     def get_serializer(self):
         return self._serializer
 
+    def close(self):
+        """Close the middleware connection and clean up resources.
+
+        This should be called before the Python process exits to ensure
+        clean shutdown of subscriber tasks and connections.
+        """
+        if hasattr(self._transport, 'close'):
+            self._transport.close()
+
     def publish_raw(self, message_type, topic, payload):
         self._transport.publish_raw(message_type, topic, payload)
 

--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -1,10 +1,12 @@
 use std::{error::Error, sync::Arc};
 
 use async_trait::async_trait;
+use log::{error, info};
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json;
-use tokio::task;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 use crate::{
     middleware::{
@@ -35,6 +37,7 @@ impl Serializer for ZenohSerializer {
 pub struct ZenohMiddleware {
     session: tokio::sync::OnceCell<zenoh::Session>,
     runtime: Arc<tokio::runtime::Runtime>,
+    subscriber_handles: Arc<Mutex<Vec<JoinHandle<()>>>>,
 }
 
 impl ZenohMiddleware {
@@ -44,7 +47,37 @@ impl ZenohMiddleware {
             runtime: Arc::new(
                 tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime"),
             ),
+            subscriber_handles: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Shutdown the Zenoh middleware, cancelling all subscriber tasks and closing the session.
+    pub fn shutdown(&self) {
+        // Cancel all subscriber tasks
+        let handles = self.subscriber_handles.clone();
+        let session = self.session.get().cloned();
+
+        self.runtime.block_on(async {
+            let mut handles_lock = handles.lock().await;
+            let num_handles = handles_lock.len();
+            for handle in handles_lock.drain(..) {
+                handle.abort();
+            }
+
+            // Close the session if it was initialized
+            if let Some(sess) = session {
+                if let Err(e) = sess.close().await {
+                    error!("Error closing Zenoh session: {:?}", e);
+                }
+            }
+
+            if num_handles > 0 {
+                info!(
+                    "ZenohMiddleware: Shutdown complete ({} subscriber tasks cancelled)",
+                    num_handles
+                );
+            }
+        });
     }
 }
 
@@ -91,11 +124,14 @@ impl MiddlewareRaw for ZenohMiddleware {
 
         let subscriber = session.declare_subscriber(topic).await.unwrap();
 
-        task::spawn(async move {
+        let handle = tokio::task::spawn(async move {
             while let Ok(sample) = subscriber.recv_async().await {
                 let _ = callback(&sample.payload().to_bytes());
             }
         });
+
+        // Track the subscriber handle for cleanup
+        self.subscriber_handles.lock().await.push(handle);
 
         Ok(())
     }
@@ -119,11 +155,14 @@ impl MiddlewareRaw for ZenohMiddleware {
         for (_message_type, topic) in topics {
             let subscriber = session.declare_subscriber(&topic).await.unwrap();
             let callback_clone = Arc::clone(&callback_arc);
-            task::spawn(async move {
+            let handle = tokio::task::spawn(async move {
                 while let Ok(sample) = subscriber.recv_async().await {
                     let _ = callback_clone(&sample.payload().to_bytes());
                 }
             });
+
+            // Track the subscriber handle for cleanup
+            self.subscriber_handles.lock().await.push(handle);
         }
 
         Ok(())
@@ -144,6 +183,13 @@ impl ZenohMiddleware {
     #[new]
     fn pynew(_py: Python) -> PyResult<Self> {
         Ok(Self::new())
+    }
+
+    /// Close the Zenoh middleware, cancelling all subscriber tasks and closing the session.
+    /// This should be called before the Python process exits to ensure clean shutdown.
+    #[pyo3(name = "close")]
+    fn pyclose(&self) {
+        self.shutdown();
     }
 
     #[pyo3(name = "publish")]

--- a/aerosim-world-link/Cargo.lock
+++ b/aerosim-world-link/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "enum_dispatch",
  "futures",
  "futures-util",
+ "log",
  "pyo3",
  "pythonize",
  "rdkafka",

--- a/aerosim/src/aerosim/core/simulation.py
+++ b/aerosim/src/aerosim/core/simulation.py
@@ -203,6 +203,10 @@ class AeroSim:
             if not task.done():
                 task.cancel()
 
+        # Close the middleware transport to clean up subscriber tasks and connections
+        if self.transport:
+            self.transport.close()
+
         print("AeroSim simulation stopped.")
 
     def on_sim_clock_step(self, data, _) -> None:

--- a/examples/autopilot_daa_scenario.py
+++ b/examples/autopilot_daa_scenario.py
@@ -415,6 +415,8 @@ class DAAScenario:
             # Clean up
             if self.aerosim:
                 self.aerosim.stop()
+            if self.transport:
+                self.transport.close()
             logger.info("Simulation stopped")
 
 


### PR DESCRIPTION
Add proper shutdown support to ZenohMiddleware to prevent the "FATAL: exception not rethrown" error during Python process exit.

Changes:
- Track spawned subscriber task handles in ZenohMiddleware
- Add shutdown() method that aborts subscriber tasks and closes session
- Expose close() method to Python via pyo3
- Add close() method to BaseMiddleware Python wrapper
- Call transport.close() in AeroSim.stop() and scenario cleanup

The error occurred because Zenoh subscriber tasks and the tokio runtime were still active when Python tried to exit, causing pthread cleanup to fail.