### PR TITLE
Clear compiler warnings across workspace and aerosim-world-link

### DIFF
--- a/aerosim-data/src/middleware/kafka.rs
+++ b/aerosim-data/src/middleware/kafka.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use bincode;
 use futures_util::StreamExt;
 use pyo3::prelude::*;
 use rdkafka::{

--- a/aerosim-data/src/middleware/mod.rs
+++ b/aerosim-data/src/middleware/mod.rs
@@ -287,6 +287,7 @@ pub trait Middleware: MiddlewareRaw {
     }
 }
 
+#[allow(dead_code)]
 trait PyMiddleware: Middleware {
     async fn pypublish_impl(
         &self,

--- a/aerosim-world-link/src/message_handler.rs
+++ b/aerosim-world-link/src/message_handler.rs
@@ -8,14 +8,13 @@ use log::{info, warn};
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::mpsc::error::TryRecvError;
-use uuid::Uuid;
 
 use aerosim_data::{
     middleware::{
         BincodeSerializer, Metadata, Middleware, MiddlewareEnum, MiddlewareRaw, MiddlewareRegistry,
         Serializer,
     },
-    types::{CompressedImage, Image, JsonData, TimeStamp},
+    types::{CompressedImage, Image, JsonData},
     AerosimMessage,
 };
 
@@ -23,6 +22,7 @@ use aerosim_data::{
 struct RendererConfig {
     #[serde(rename = "renderer_id")]
     instance_id: String,
+    #[allow(dead_code)]
     role: String,
     sensors: Vec<String>,
 }
@@ -199,7 +199,7 @@ impl MessageHandler {
     pub fn stop(&mut self) -> Result<(), ()> {
         info!("[aerosim.renderer.message_handler] Stopping message handler.");
 
-        self.tx_stop.blocking_send(true);
+        let _ = self.tx_stop.blocking_send(true);
         let handle = self
             .thread_handle
             .take()
@@ -341,14 +341,14 @@ async fn message_handler_main(
             Ok((topic, image)) => {
                 // TODO: Properly pass `timestamp_sim` and `timestamp_platform` from the renderer.
                 let metadata = Metadata::new(&topic, &CompressedImage::get_type_name(), None, None);
-                let compressed_image = match image.compress() {
+                match image.compress() {
                     Ok(compressed_image) => {
                         // The Kafka middleware defaults to a JSON serializer. A Bincode serializer is used
                         // here to improve encoding and decoding performance, handled through the middleware's raw API.
                         let serializer = BincodeSerializer {};
                         match serializer.serialize_message(&metadata, &compressed_image) {
                             Some(payload) => {
-                                transport
+                                let _ = transport
                                     .publish_raw(
                                         &CompressedImage::get_type_name(),
                                         &topic,
@@ -360,7 +360,7 @@ async fn message_handler_main(
                         }
                     }
                     Err(_) => eprintln!("Could not compress raw image to jpeg"),
-                };
+                }
             }
             Err(TryRecvError::Empty) => { /* pass to continue looping */ }
             Err(e) => eprintln!("Error receiving image: {:?}", e),
@@ -513,7 +513,7 @@ fn handle_orchestrator_command_message(
 
 fn filter_scene_graph_data(
     scene_graph: &serde_json::Value,
-    assigned_sensors: Vec<String>,
+    _assigned_sensors: Vec<String>,
     instance_id: &str,
 ) -> serde_json::Value {
     let mut filtered_scene_graph = scene_graph.clone();

--- a/aerosim-world/src/scene_graph.rs
+++ b/aerosim-world/src/scene_graph.rs
@@ -49,6 +49,7 @@ pub struct SceneGraph {
     // entity_effector_state_topic_map is a map of "topic" -> ("entity_name", effector_idx)
     entity_effector_state_topic_map: HashMap<String, (String, usize)>,
     origin_lla: (f64, f64, f64),
+    #[allow(dead_code)]
     rotate_bevy_to_ned: bevy_math::Quat,
     rotate_ned_to_bevy: bevy_math::Quat,
 }
@@ -74,6 +75,7 @@ impl SceneGraph {
         }
     }
 
+    #[allow(dead_code)]
     fn bevy_xyz_to_ned(&self, bevy_point: bevy_math::Vec3) -> bevy_math::Vec3 {
         let xform = bevy_transform::components::Transform::from_rotation(self.rotate_bevy_to_ned);
         xform.transform_point(bevy_point)
@@ -94,6 +96,7 @@ impl SceneGraph {
         bevy_q
     }
 
+    #[allow(dead_code)]
     fn bevy_quat_to_ned_quat(&self, bevy_quat: bevy_math::Quat) -> bevy_math::Quat {
         let (yaw, pitch, roll) = bevy_quat.to_euler(bevy_math::EulerRot::default());
         let ned_q = bevy_math::Quat::from_euler(bevy_math::EulerRot::ZYXEx, -roll, pitch, -yaw);


### PR DESCRIPTION
## Summary
- Clear all Rust compiler warnings across the workspace and aerosim-world-link crate
- Improves code quality and ensures clean builds with `-v` flag

## Changes

**aerosim-data/src/middleware/kafka.rs**
- Remove unused `bincode` import

**aerosim-data/src/middleware/mod.rs**
- Add `#[allow(dead_code)]` to `PyMiddleware` trait (kept for future Python bindings)

**aerosim-world/src/scene_graph.rs**
- Add `#[allow(dead_code)]` to `rotate_bevy_to_ned` field and coordinate conversion methods (`bevy_xyz_to_ned`, `bevy_quat_to_ned_quat`) that are kept for future use

**aerosim-world-link/src/message_handler.rs**
- Remove unused imports (`uuid::Uuid`, `TimeStamp`)
- Add `#[allow(dead_code)]` to unused `role` field in `RendererConfig` struct
- Fix unused `Result` warnings by explicitly ignoring with `let _ =`
- Fix unused variable warning by removing unnecessary outer assignment in image compression logic
- Prefix unused parameter with underscore (`_assigned_sensors`)

## Test plan
- [x] Run `./build_aerosim.sh -v` and verify no warnings
- [x] Run `cargo check --workspace` and verify no warnings
