### PR TITLE
Update FMI crate dependency fork to eliminate FMU model instance lifetime reference workarounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -824,21 +824,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -935,21 +935,11 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -1151,21 +1141,6 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1737,6 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1754,8 +1730,8 @@ dependencies = [
 
 [[package]]
 name = "fmi"
-version = "0.4.1"
-source = "git+https://github.com/edufford/rust-fmi.git?branch=edufford%2Fint_array#b5ac60efb383a445a503b4fc42baacf244846560"
+version = "0.5.0"
+source = "git+https://github.com/edufford/rust-fmi.git?branch=main_fix_annotations#f1801cf25a7abb8515cb32edbd1858a554a3ce13"
 dependencies = [
  "arrow",
  "built",
@@ -1766,34 +1742,34 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "paste",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "url",
  "zip",
 ]
 
 [[package]]
 name = "fmi-schema"
-version = "0.2.1"
-source = "git+https://github.com/edufford/rust-fmi.git?branch=edufford%2Fint_array#b5ac60efb383a445a503b4fc42baacf244846560"
+version = "0.5.0"
+source = "git+https://github.com/edufford/rust-fmi.git?branch=main_fix_annotations#f1801cf25a7abb8515cb32edbd1858a554a3ce13"
 dependencies = [
  "arrow",
  "chrono",
  "document-features",
+ "hard-xml",
  "itertools 0.14.0",
  "lenient_semver",
  "semver",
- "thiserror 1.0.69",
- "yaserde",
- "yaserde_derive",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "fmi-sys"
-version = "0.1.2"
-source = "git+https://github.com/edufford/rust-fmi.git?branch=edufford%2Fint_array#b5ac60efb383a445a503b4fc42baacf244846560"
+version = "0.5.0"
+source = "git+https://github.com/edufford/rust-fmi.git?branch=main_fix_annotations#f1801cf25a7abb8515cb32edbd1858a554a3ce13"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.72.1",
  "cc",
  "document-features",
  "libloading",
@@ -2027,6 +2003,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hard-xml"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b07b8ba970e18a03dbb79f6786b6e4d6f198a0ac839aa5182017001bb8dee17"
+dependencies = [
+ "hard-xml-derive",
+ "jetscii",
+ "lazy_static",
+ "memchr",
+ "xmlparser",
+]
+
+[[package]]
+name = "hard-xml-derive"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c43e7c3212bd992c11b6b9796563388170950521ae8487f5cdf6f6e792f1c8"
+dependencies = [
+ "bitflags",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,12 +2049,6 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2351,6 +2346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2553,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,6 +2586,15 @@ checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2682,27 +2718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "lzma-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
-dependencies = [
- "byteorder",
- "crc",
-]
-
-[[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3313,6 +3328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d558c559f0450f16f2a27a1f017ef38468c1090c9ce63c8e51366232d53717b4"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,7 +3436,7 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -4469,7 +4490,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5606,43 +5627,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.27"
+name = "xmlparser"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
-
-[[package]]
-name = "yaserde"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caef36c14c52a48ebefe7c55192eb2edbbe7e0e2ac3671b7dd713f8179056428"
-dependencies = [
- "log",
- "xml-rs",
-]
-
-[[package]]
-name = "yaserde_derive"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad72268af8b1cb89f8f53dec17b3c72277c19ba5492b50ffa829aebbf55a187f"
-dependencies = [
- "heck 0.4.1",
- "log",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "xml-rs",
-]
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
@@ -6280,33 +6268,36 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "aes",
  "arbitrary",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
  "deflate64",
- "displaydoc",
  "flate2",
  "getrandom 0.3.3",
  "hmac",
  "indexmap 2.11.0",
- "lzma-rs",
+ "liblzma",
  "memchr",
  "pbkdf2",
+ "ppmd-rust",
  "sha1",
- "thiserror 2.0.16",
  "time",
- "xz2",
  "zeroize",
  "zopfli",
  "zstd 0.13.3",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zopfli"

--- a/aerosim-world/Cargo.toml
+++ b/aerosim-world/Cargo.toml
@@ -26,6 +26,6 @@ bevy_ecs = "0.15.0"
 bevy_hierarchy = "0.15.0"
 bevy_math = "0.15.0"
 bevy_transform = "0.15.0"
-fmi = { git = "https://github.com/edufford/rust-fmi.git", branch = "edufford/int_array" }
+fmi = { git = "https://github.com/edufford/rust-fmi.git", branch = "main_fix_annotations" }
 itertools = "0.14.0"
 mcap="0.15.0"

--- a/aerosim-world/src/fmu_driver.rs
+++ b/aerosim-world/src/fmu_driver.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 use serde_json::Value;
 
 use fmi::fmi2::import::Fmi2Import;
-use fmi::fmi3::{instance::CoSimulation, schema::Causality};
+use fmi::fmi3::{CoSimulation, schema::Causality};
 use fmi::schema::traits::FmiModelDescription;
 use fmi::traits::FmiInstance;
 

--- a/aerosim-world/src/fmu_utils.rs
+++ b/aerosim-world/src/fmu_utils.rs
@@ -362,7 +362,7 @@ pub fn set_init_value_fmu3(
     fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
 ) {
     info!(
-        "[{}] Setting initial value '{}' = {:?}",
+        "[{}] Setting initial value '{}' = {}",
         fmu_id, init_var, init_value
     );
 

--- a/aerosim-world/src/fmu_utils.rs
+++ b/aerosim-world/src/fmu_utils.rs
@@ -182,8 +182,8 @@ impl Fmi3ModelVarInfo {
 
 // ----------------------------------------------------------------------------
 // Fmi3Model struct to combine Import and Instance.
-// With the new fmi v0.5.0+ API, instances no longer hold lifetime references
-// to the import, so we can store them together without lifetime workarounds.
+// With the fmi crate's main branch (post-v0.5.0), instances no longer hold
+// lifetime references to the import, so we can store them together directly.
 
 pub struct Fmi3Model {
     fmu_import: Fmi3Import,
@@ -257,46 +257,6 @@ impl Fmi3Model {
 }
 
 // ----------------------------------------------------------------------------
-// Alternative way to deal with Fmi3Model import lifetime through a raw pointer
-
-// pub struct FmiModel<'a> {
-//     fmu_import: Box<Fmi3Import>,
-//     fmu_instance: fmi::fmi3::instance::InstanceCS<'a>,
-// }
-
-// impl<'a> FmiModel<'a> {
-//     pub fn new(fmu_filename: PathBuf) -> Self {
-//         // Allocate the import on the heap.
-//         let fmu_import: Box<Fmi3Import> =
-//             Box::new(fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file."));
-
-//         // Manually extend the lifetime of the reference to match 'a through a raw pointer.
-//         let fmu_import_ref: &'a Fmi3Import =
-//             unsafe { &*(fmu_import.as_ref() as *const Fmi3Import) };
-
-//         let fmu_instance = fmu_import_ref
-//             .instantiate_cs("instance1", false, true, false, false, &[])
-//             .expect("Unable to instantiate FMU instance.");
-
-//         Self {
-//             fmu_import,
-//             fmu_instance,
-//         }
-//     }
-// }
-
-// ----------------------------------------------------------------------------
-// Alternative way to deal with Fmi3Model import lifetime using 'ouroboros' crate
-
-// #[self_referencing]
-// pub struct FmiModel {
-//     fmu_import: Rc<Fmi3Import>,
-//     #[covariant]
-//     #[borrows(fmu_import)]
-//     fmu_instance: fmi::fmi3::instance::InstanceCS<'this>,
-// }
-
-// ----------------------------------------------------------------------------
 // FMI 2.0 + 3.0 enum type placeholders to be implemented in the future
 
 // pub enum FmiImportEnum {
@@ -304,14 +264,14 @@ impl Fmi3Model {
 //     Fmi3Import(Fmi3Import),
 // }
 
-// pub enum FmiInstanceEnum<'a> {
-//     Fmi2Instance(fmi::fmi2::instance::InstanceCS<'a>),
-//     Fmi3Instance(fmi::fmi3::instance::InstanceCS<'a>),
+// pub enum FmiInstanceEnum {
+//     Fmi2Instance(fmi::fmi2::instance::InstanceCS),
+//     Fmi3Instance(fmi::fmi3::instance::InstanceCS),
 // }
 
-// pub enum ModelDescriptionEnum<'a> {
-//     Fmi2ModelDescription(&'a fmi::fmi2::schema::Fmi2ModelDescription),
-//     Fmi3ModelDescription(&'a fmi::fmi3::schema::Fmi3ModelDescription),
+// pub enum ModelDescriptionEnum<'md> {
+//     Fmi2ModelDescription(&'md fmi::fmi2::schema::Fmi2ModelDescription),
+//     Fmi3ModelDescription(&'md fmi::fmi3::schema::Fmi3ModelDescription),
 // }
 
 // ---------------------------------------------------------------------------

--- a/aerosim-world/src/fmu_utils.rs
+++ b/aerosim-world/src/fmu_utils.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 
 use serde_json::Value;
 
-use fmi::fmi3::{import::Fmi3Import, instance::Common, schema::VariableType};
+use fmi::fmi3::{import::Fmi3Import, schema::VariableType, Common, Fmi3Model as Fmi3ModelTrait, GetSet};
 use fmi::schema::fmi3::ArrayableVariableTrait;
-use fmi::traits::{FmiImport, FmiInstance};
+use fmi::traits::FmiImport;
+use std::ffi::CString;
 
 use aerosim_data::{
     middleware::{Metadata, Middleware, MiddlewareEnum, MiddlewareRaw, Serializer, SerializerEnum},
@@ -72,70 +73,60 @@ pub struct Fmi3ModelVarInfo {
 impl Fmi3ModelVarInfo {
     pub fn new(fmu_id: &str, fmi3_model: &Fmi3Model) -> Self {
         let mut fmu_var_info: HashMap<String, Fmi3VarInfo> = HashMap::new();
-        let fmu_model_desc = fmi3_model.get_fmu_instance_ref().model_description();
+        let fmu_model_desc = fmi3_model.model_description();
 
         // Collect all of the variable value references
+        // Store the vectors first to extend their lifetime
+        let float64_vars = fmu_model_desc.model_variables.float64();
+        let float32_vars = fmu_model_desc.model_variables.float32();
+        let int64_vars = fmu_model_desc.model_variables.int64();
+        let int32_vars = fmu_model_desc.model_variables.int32();
+        let int16_vars = fmu_model_desc.model_variables.int16();
+        let int8_vars = fmu_model_desc.model_variables.int8();
+        let uint64_vars = fmu_model_desc.model_variables.uint64();
+        let uint32_vars = fmu_model_desc.model_variables.uint32();
+        let uint16_vars = fmu_model_desc.model_variables.uint16();
+        let uint8_vars = fmu_model_desc.model_variables.uint8();
+        let boolean_vars = fmu_model_desc.model_variables.boolean();
+        let string_vars = fmu_model_desc.model_variables.string();
+
         let all_fmu_var_iter = itertools::chain!(
-            fmu_model_desc
-                .model_variables
-                .float64
+            float64_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .float32
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            float32_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int64
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            int64_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int32
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            int32_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int16
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            int16_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .int8
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            int8_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint64
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            uint64_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint32
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            uint32_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint16
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            uint16_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .uint8
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            uint8_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .boolean
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            boolean_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
-            fmu_model_desc
-                .model_variables
-                .string
+                .map(|v| *v as &dyn ArrayableVariableTrait),
+            string_vars
                 .iter()
-                .map(|v| v as &dyn ArrayableVariableTrait),
+                .map(|v| *v as &dyn ArrayableVariableTrait),
         );
 
         for fmu_var in all_fmu_var_iter {
@@ -146,10 +137,11 @@ impl Fmi3ModelVarInfo {
             let fmu_var_dim: Vec<u64> = fmu_var
                 .dimensions()
                 .iter()
-                .map(|d| {
-                    d.start
-                        .expect("Error: Only dimensions using 'start' value are supported.")
-                        as u64
+                .map(|d| match d {
+                    fmi::fmi3::schema::Dimension::Fixed(start) => *start as u64,
+                    fmi::fmi3::schema::Dimension::Variable(_) => {
+                        panic!("Error: Only dimensions using 'Fixed' value are supported.")
+                    }
                 })
                 .collect();
             let fmu_var_tot_dim: usize = fmu_var_dim
@@ -189,26 +181,24 @@ impl Fmi3ModelVarInfo {
 }
 
 // ----------------------------------------------------------------------------
-// Fmi3Model struct to combine Import and Instance (that has a reference to
-// the Import bindings). The Import lifetime is made static through a leaked
-// Box pointer to guarantee it outlives the instance.
+// Fmi3Model struct to combine Import and Instance.
+// With the new fmi v0.5.0+ API, instances no longer hold lifetime references
+// to the import, so we can store them together without lifetime workarounds.
 
 pub struct Fmi3Model {
-    #[allow(unused)]
-    fmu_import: Box<Fmi3Import>,
-    fmu_instance: fmi::fmi3::instance::InstanceCS<'static>,
+    fmu_import: Fmi3Import,
+    fmu_instance: fmi::fmi3::instance::InstanceCS,
 }
 
 impl Fmi3Model {
     pub fn new(fmu_filename: PathBuf) -> Self {
-        // Allocate the import on the heap and leak it to get a 'static reference.
-        let fmu_import_box: Box<Fmi3Import> =
-            Box::new(fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file."));
+        let fmu_import: Fmi3Import =
+            fmi::import::from_path(&fmu_filename).expect("Unable to import FMU file.");
 
         if std::env::consts::OS == "windows" {
             // Add extracted lib path to system path so any dependency libs can also be found and loaded
-            let archive_path = fmu_import_box.archive_path();
-            let mut shared_lib_path = fmu_import_box
+            let archive_path = fmu_import.archive_path();
+            let mut shared_lib_path = fmu_import
                 .shared_lib_path("")
                 .expect("Unable to get FMU shared lib path.");
             let _ = shared_lib_path.pop(); // remove blank '.dll' that shared_lib_path() adds at the end
@@ -230,15 +220,9 @@ impl Fmi3Model {
             // TODO Update the Linux path like above
         }
 
-        let fmu_import_static: &'static Fmi3Import = Box::leak(fmu_import_box);
-
-        let fmu_instance = fmu_import_static
+        let fmu_instance = fmu_import
             .instantiate_cs("instance1", false, true, false, false, &[])
             .expect("Unable to instantiate FMU instance.");
-
-        // Rebuild the Box to deallocate it later.
-        let fmu_import =
-            unsafe { Box::from_raw(fmu_import_static as *const Fmi3Import as *mut Fmi3Import) };
 
         let fmu_model_desc = fmu_import.model_description();
 
@@ -253,11 +237,15 @@ impl Fmi3Model {
         }
     }
 
-    pub fn get_fmu_instance_ref(&self) -> &fmi::fmi3::instance::InstanceCS<'static> {
+    pub fn model_description(&self) -> &fmi::fmi3::schema::Fmi3ModelDescription {
+        self.fmu_import.model_description()
+    }
+
+    pub fn get_fmu_instance_ref(&self) -> &fmi::fmi3::instance::InstanceCS {
         &self.fmu_instance
     }
 
-    pub fn get_fmu_instance_mut(&mut self) -> &mut fmi::fmi3::instance::InstanceCS<'static> {
+    pub fn get_fmu_instance_mut(&mut self) -> &mut fmi::fmi3::instance::InstanceCS {
         &mut self.fmu_instance
     }
 
@@ -458,8 +446,12 @@ pub fn set_init_value_fmu3(
             let _ = fmu_instance.set_boolean(&[fmu_var_info.fmu_var_ref], &values);
         }
         VariableType::FmiString => {
-            let values: Vec<&str> = value_array.iter().filter_map(|v| v.as_str()).collect();
-            let _ = fmu_instance.set_string(&[fmu_var_info.fmu_var_ref], values.into_iter());
+            let values: Vec<CString> = value_array
+                .iter()
+                .filter_map(|v| v.as_str())
+                .filter_map(|s| CString::new(s).ok())
+                .collect();
+            let _ = fmu_instance.set_string(&[fmu_var_info.fmu_var_ref], &values);
         }
         _ => {
             warn!(
@@ -634,13 +626,14 @@ pub fn set_fmu3_from_json(
             let _ = fmu_instance.set_boolean(&[var_info.fmu_var_ref], &values);
         }
         VariableType::FmiString => {
-            let values = new_val
+            let values: Vec<CString> = new_val
                 .as_array()
                 .expect("Not a valid array of string.")
                 .iter()
                 .filter_map(|v| v.as_str())
-                .collect::<Vec<&str>>();
-            let _ = fmu_instance.set_string(&[var_info.fmu_var_ref], values.into_iter());
+                .filter_map(|s| CString::new(s).ok())
+                .collect();
+            let _ = fmu_instance.set_string(&[var_info.fmu_var_ref], &values);
         }
         _ => {
             warn!(
@@ -762,16 +755,19 @@ pub fn get_fmu3_string(
     fmu_var_info: &Fmi3VarInfo,
     fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
 ) -> Vec<String> {
-    let mut values: Vec<String> = vec![String::new(); fmu_var_info.fmu_var_tot_dim];
+    let mut values: Vec<CString> = vec![CString::default(); fmu_var_info.fmu_var_tot_dim];
     let _ = fmu_instance.get_string(&[fmu_var_info.fmu_var_ref], &mut values);
     values
+        .into_iter()
+        .map(|cs| cs.into_string().unwrap_or_default())
+        .collect()
 }
 
 pub fn set_json_from_fmu3(
     fmu_id: &str,
     fmu_var_name: &str,
     fmu_model_var_info: &Fmi3ModelVarInfo,
-    fmu_instance: &mut fmi::fmi3::instance::InstanceCS<'_>,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
     msg_struct_json: &mut serde_json::Value,
     json_var: &str,
     json_var_as_pointer: bool,
@@ -842,7 +838,7 @@ pub async fn publish_component_output_topics_fmu3(
     fmu_id: &str,
     fmu_config_json: &serde_json::Value,
     fmu_model_var_info: &Fmi3ModelVarInfo,
-    fmu_instance: &mut fmi::fmi3::instance::InstanceCS<'_>,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
     timestamp: &TimeStamp,
     middleware: &Arc<MiddlewareEnum>,
     serializer: &SerializerEnum,
@@ -986,7 +982,7 @@ pub fn pack_raw_aerosim_fmu_msg<T: AerosimMessage + Default>(
     fmu_id: &str,
     var_prefix: &str,
     fmu_model_var_info: &Fmi3ModelVarInfo,
-    fmu_instance: &mut fmi::fmi3::instance::InstanceCS<'_>,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
     serializer: &SerializerEnum,
     metadata: &Metadata,
 ) -> Vec<u8> {
@@ -1024,7 +1020,7 @@ pub async fn publish_aux_output_topics_fmu3(
     fmu_id: &str,
     fmu_config_json: &serde_json::Value,
     fmu_model_var_info: &Fmi3ModelVarInfo,
-    fmu_instance: &mut fmi::fmi3::instance::InstanceCS<'_>,
+    fmu_instance: &mut fmi::fmi3::instance::InstanceCS,
     timestamp: &TimeStamp,
     middleware: &Arc<MiddlewareEnum>,
 ) {


### PR DESCRIPTION
## Summary
- Update aerosim-world to use the fmi crate's main branch (post-v0.5.0) API where [instances no longer hold lifetime references to the import](https://github.com/jondo2010/rust-fmi/pull/130)
- Fix FMU initial value logging to show clean JSON values without type wrappers
- Remove obsolete commented workarounds for FMI lifetime restrictions

## Test plan
- [x] Build aerosim-world workspace successfully
- [x] Run FMU driver with an FMI 3.0 FMU and verify it loads and steps correctly (autopilot_daa_scenario.py)
- [x] Verify initial values are logged with clean JSON format (e.g., `[0.0, 0.0, 0.0]` instead of `Array [Number(0.0), Number(0.0), Number(0.0)]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
