### PR TITLE
Add C++ FMU template for creating new FMUs

### DIFF
--- a/aerosim-dynamics-models/build_template_fmu.sh
+++ b/aerosim-dynamics-models/build_template_fmu.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build script for Template FMU
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CPP_DIR="${SCRIPT_DIR}/cpp/template_fmu"
+BUILD_DIR="${CPP_DIR}/build"
+
+echo "Building Template FMU..."
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . --config Release
+
+if [ -f "${BUILD_DIR}/template_fmu.fmu" ]; then
+    cp "${BUILD_DIR}/template_fmu.fmu" "${SCRIPT_DIR}/../examples/fmu/"
+    echo "Built and copied template_fmu.fmu to ../examples/fmu"
+else
+    echo "Build failed - FMU file not found"
+    exit 1
+fi

--- a/aerosim-dynamics-models/cpp/template_fmu/CMakeLists.txt
+++ b/aerosim-dynamics-models/cpp/template_fmu/CMakeLists.txt
@@ -1,0 +1,98 @@
+# Template FMU CMake Build Configuration
+#
+# To create a new FMU from this template:
+# 1. Copy this directory and rename it
+# 2. Update FMU_MODEL_NAME below to match your new FMU name
+# 3. Update the source file name in add_library() if you renamed it
+# 4. Run the build script or: mkdir build && cd build && cmake .. && cmake --build .
+
+cmake_minimum_required(VERSION 3.14)
+project(template_fmu VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# =============================================================================
+# FMU Configuration - UPDATE THIS FOR YOUR FMU
+# =============================================================================
+set(FMU_MODEL_NAME "template_fmu")
+set(FMU_SOURCE_FILE "template_fmu.cpp")
+
+# =============================================================================
+# Fetch CPPFMU (FMI 3.0) from PythonFMU3 repository
+# =============================================================================
+include(FetchContent)
+
+if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 NEW)
+endif()
+
+FetchContent_Declare(
+    pythonfmu3
+    GIT_REPOSITORY https://github.com/stephensmith25/PythonFMU3.git
+    GIT_TAG        master
+    EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(pythonfmu3)
+
+set(CPPFMU_SOURCE_DIR "${pythonfmu3_SOURCE_DIR}/pythonfmu3/pythonfmu-export/src")
+message(STATUS "Using CPPFMU sources from: ${CPPFMU_SOURCE_DIR}")
+
+# =============================================================================
+# Platform Detection
+# =============================================================================
+if(WIN32)
+    set(FMU_PLATFORM "x86_64-windows")
+elseif(APPLE)
+    set(FMU_PLATFORM "x86_64-darwin")
+else()
+    set(FMU_PLATFORM "x86_64-linux")
+endif()
+
+# =============================================================================
+# Build the FMU Shared Library
+# =============================================================================
+add_library(${FMU_MODEL_NAME} SHARED
+    ${FMU_SOURCE_FILE}
+    ${CPPFMU_SOURCE_DIR}/cppfmu/cppfmu_cs.cpp
+    ${CPPFMU_SOURCE_DIR}/cppfmu/fmi_functions.cpp
+)
+
+target_include_directories(${FMU_MODEL_NAME} PRIVATE
+    ${CPPFMU_SOURCE_DIR}
+)
+
+# Suppress MSVC warnings for unimplemented optional FMI 3.0 features in CPPFMU
+if(MSVC)
+    set_source_files_properties(
+        ${CPPFMU_SOURCE_DIR}/cppfmu/fmi_functions.cpp
+        PROPERTIES COMPILE_FLAGS "/wd4297"
+    )
+endif()
+
+set_target_properties(${FMU_MODEL_NAME} PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/binaries/${FMU_PLATFORM}"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/binaries/${FMU_PLATFORM}"
+    PREFIX ""
+)
+
+# =============================================================================
+# Package the FMU
+# =============================================================================
+set(FMU_STAGING_DIR "${CMAKE_BINARY_DIR}/fmu_staging")
+set(FMU_OUTPUT_FILE "${CMAKE_BINARY_DIR}/${FMU_MODEL_NAME}.fmu")
+
+add_custom_command(
+    OUTPUT ${FMU_OUTPUT_FILE}
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${FMU_STAGING_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${FMU_STAGING_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${FMU_STAGING_DIR}/binaries/${FMU_PLATFORM}
+    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/modelDescription.xml ${FMU_STAGING_DIR}/
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${FMU_MODEL_NAME}> ${FMU_STAGING_DIR}/binaries/${FMU_PLATFORM}/
+    COMMAND ${CMAKE_COMMAND} -E chdir ${FMU_STAGING_DIR} ${CMAKE_COMMAND} -E tar cf ${FMU_OUTPUT_FILE} --format=zip .
+    DEPENDS ${FMU_MODEL_NAME} ${CMAKE_SOURCE_DIR}/modelDescription.xml
+    COMMENT "Creating FMU package: ${FMU_OUTPUT_FILE}"
+)
+
+add_custom_target(fmu ALL DEPENDS ${FMU_OUTPUT_FILE})

--- a/aerosim-dynamics-models/cpp/template_fmu/modelDescription.xml
+++ b/aerosim-dynamics-models/cpp/template_fmu/modelDescription.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Template FMU Model Description
+
+  This file defines the FMU's interface: its variables, types, and capabilities.
+  Update this file when adding or modifying FMU variables.
+
+  Key attributes to update when creating a new FMU:
+  - modelName: Human-readable name
+  - instantiationToken: Unique identifier (can be any string)
+  - modelIdentifier: Must match the shared library name (without extension)
+
+  Value reference conventions used in this template:
+  - 0: Time (independent, required by FMI 3.0)
+  - 1-99: Inputs
+  - 100-199: Parameters
+  - 200-299: Outputs
+-->
+<fmiModelDescription
+    fmiVersion="3.0"
+    modelName="template_fmu"
+    instantiationToken="{template-fmu-guid}"
+    description="Template FMU - multiply input by gain"
+    author="AeroSim"
+    generationTool="CPPFMU"
+    variableNamingConvention="structured">
+
+    <CoSimulation
+        modelIdentifier="template_fmu"
+        canHandleVariableCommunicationStepSize="true"
+        canBeInstantiatedOnlyOncePerProcess="false"
+        canGetAndSetFMUState="false"
+        canSerializeFMUState="false"
+        providesDirectionalDerivatives="false"
+        providesAdjointDerivatives="false"/>
+
+    <DefaultExperiment startTime="0.0" stepSize="0.01"/>
+
+    <ModelVariables>
+        <!--
+          Variable Types:
+          - Float64, Float32: Floating point numbers
+          - Int32, Int64, UInt64: Integers
+          - Boolean: True/false
+          - String: Text
+
+          Causality:
+          - input: Set by simulation environment
+          - output: Computed by FMU
+          - parameter: Tunable value (can be set before/during simulation)
+          - independent: Time variable (exactly one required in FMI 3.0)
+
+          Variability:
+          - continuous: Can change at any time
+          - discrete: Changes at events
+          - tunable: Can be changed between steps
+          - constant: Never changes
+        -->
+
+        <!-- Independent time variable (required by FMI 3.0) -->
+        <Float64
+            name="time"
+            valueReference="0"
+            causality="independent"
+            variability="continuous"
+            description="Simulation time"/>
+
+        <!-- Inputs (valueReference 1-99) -->
+        <Float64
+            name="input"
+            valueReference="1"
+            causality="input"
+            variability="continuous"
+            start="0.0"
+            description="Input value to be multiplied by gain"/>
+
+        <!-- Parameters (valueReference 100-199) -->
+        <Float64
+            name="gain"
+            valueReference="100"
+            causality="parameter"
+            variability="tunable"
+            start="1.0"
+            description="Gain multiplier"/>
+
+        <!-- Outputs (valueReference 200-299) -->
+        <Float64
+            name="output"
+            valueReference="200"
+            causality="output"
+            variability="continuous"
+            initial="exact"
+            start="0.0"
+            description="Output = input * gain"/>
+    </ModelVariables>
+
+    <ModelStructure>
+        <!-- List all output valueReferences here -->
+        <Output valueReference="200"/>
+    </ModelStructure>
+</fmiModelDescription>

--- a/aerosim-dynamics-models/cpp/template_fmu/template_fmu.cpp
+++ b/aerosim-dynamics-models/cpp/template_fmu/template_fmu.cpp
@@ -1,0 +1,243 @@
+// Template FMU - A starting point for creating C++ FMUs
+//
+// Uses the FMI 3.0 version of CPPFMU from pythonfmu3:
+// https://github.com/stephensmith25/PythonFMU3
+//
+// This template demonstrates the minimal structure needed for a C++ FMU.
+// The example multiplies an input value by a gain parameter to produce an output.
+//
+// To create a new FMU from this template:
+// 1. Copy this directory and rename it
+// 2. Update FMU_MODEL_NAME in CMakeLists.txt
+// 3. Update modelIdentifier and modelName in modelDescription.xml
+// 4. Add your variables to modelDescription.xml with unique valueReferences
+// 5. Update the kVr* constants to match your valueReferences
+// 6. Implement your logic in DoStep()
+
+#include "cppfmu/cppfmu_cs.hpp"
+
+#include <cmath>
+
+namespace {
+
+// =============================================================================
+// Value References
+// =============================================================================
+// These must match the valueReference attributes in modelDescription.xml.
+// Convention: time at 0, inputs 1-99, parameters 100-199, outputs 200-299.
+
+// Independent (time)
+constexpr cppfmu::FMIValueReference kVrTime = 0;
+
+// Inputs
+constexpr cppfmu::FMIValueReference kVrInput = 1;
+
+// Parameters (tunable)
+constexpr cppfmu::FMIValueReference kVrGain = 100;
+
+// Outputs
+constexpr cppfmu::FMIValueReference kVrOutput = 200;
+
+// =============================================================================
+// FMU Implementation
+// =============================================================================
+
+class TemplateFmu : public cppfmu::SlaveInstance {
+ public:
+  TemplateFmu()
+      : time_(0.0),
+        input_(0.0),
+        gain_(1.0),
+        output_(0.0) {}
+
+  // ---------------------------------------------------------------------------
+  // Variable Setters - Called by simulation environment to set FMU variables
+  // ---------------------------------------------------------------------------
+
+  void SetFloat64(const cppfmu::FMIValueReference vr[], std::size_t nvr,
+                  const cppfmu::FMIFloat64 value[],
+                  std::size_t /*nValues*/) override {
+    for (std::size_t i = 0; i < nvr; ++i) {
+      switch (vr[i]) {
+        // Note: kVrTime is not settable here - it's set via SetTime()
+        case kVrInput:
+          input_ = value[i];
+          break;
+        case kVrGain:
+          gain_ = value[i];
+          break;
+        // Add cases for additional variables here
+        default:
+          break;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Variable Getters - Called by simulation environment to read FMU variables
+  // ---------------------------------------------------------------------------
+
+  void GetFloat64(const cppfmu::FMIValueReference vr[], std::size_t nvr,
+                  cppfmu::FMIFloat64 value[],
+                  std::size_t /*nValues*/) const override {
+    for (std::size_t i = 0; i < nvr; ++i) {
+      switch (vr[i]) {
+        case kVrTime:
+          value[i] = time_;
+          break;
+        case kVrInput:
+          value[i] = input_;
+          break;
+        case kVrGain:
+          value[i] = gain_;
+          break;
+        case kVrOutput:
+          value[i] = output_;
+          break;
+        // Add cases for additional variables here
+        default:
+          value[i] = 0.0;
+          break;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // DoStep - Main simulation step function
+  // ---------------------------------------------------------------------------
+  // This is called each simulation step. Implement your logic here.
+  //
+  // Parameters:
+  //   current_communication_point: Current simulation time
+  //   communication_step_size: Time step size
+  //   new_step: True if this is a new step (not a rollback)
+  //   event_handling_needed: Set to true if events need handling
+  //   terminate_simulation: Set to true to request simulation termination
+  //   early_return: Set to true if returning before step_size elapsed
+  //   end_of_step: Actual end time of the step
+
+  cppfmu::FMIStatus DoStep(cppfmu::FMIFloat64 current_communication_point,
+                           cppfmu::FMIFloat64 communication_step_size,
+                           cppfmu::FMIBoolean /*new_step*/,
+                           cppfmu::FMIBoolean* event_handling_needed,
+                           cppfmu::FMIBoolean* terminate_simulation,
+                           cppfmu::FMIBoolean* early_return,
+                           cppfmu::FMIFloat64& end_of_step) override {
+    // Update time (for Co-Simulation, time advances here, not via SetTime)
+    time_ = current_communication_point + communication_step_size;
+
+    // =========================================================================
+    // YOUR LOGIC HERE
+    // =========================================================================
+    // This example simply multiplies the input by the gain.
+    // Replace this with your actual computation.
+
+    output_ = input_ * gain_;
+
+    // =========================================================================
+    // END OF YOUR LOGIC
+    // =========================================================================
+
+    // Set output flags (typically leave these as-is)
+    *event_handling_needed = cppfmu::FMIFalse;
+    *terminate_simulation = cppfmu::FMIFalse;
+    *early_return = cppfmu::FMIFalse;
+    end_of_step = time_;
+
+    return cppfmu::FMIOK;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Initialization - Compute initial output values
+  // ---------------------------------------------------------------------------
+  // ExitInitializationMode is called after all initial values have been set
+  // but before the first DoStep(). Use this to compute initial outputs.
+
+  void ExitInitializationMode() override {
+    // Compute initial output from initial input and parameter values
+    output_ = input_ * gain_;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Optional: Other initialization methods
+  // ---------------------------------------------------------------------------
+
+  // void SetupExperiment(cppfmu::FMIBoolean tolerance_defined,
+  //                      cppfmu::FMIFloat64 tolerance,
+  //                      cppfmu::FMIFloat64 start_time,
+  //                      cppfmu::FMIBoolean stop_time_defined,
+  //                      cppfmu::FMIFloat64 stop_time) override {}
+
+  // void EnterInitializationMode() override {}
+  // void Terminate() override {}
+  // void Reset() override {}
+
+  // ---------------------------------------------------------------------------
+  // Model Exchange stubs - Required by CPPFMU interface but not called for
+  // Co-Simulation FMUs. For CS, time advances via DoStep(), not SetTime().
+  // ---------------------------------------------------------------------------
+
+  void SetTime(cppfmu::FMIFloat64 time) override { time_ = time; }  // ME only
+  void GetContinuousStates(cppfmu::FMIFloat64*, std::size_t) const override {}
+  void SetContinuousStates(const cppfmu::FMIFloat64*, std::size_t) override {}
+  void GetContinuousStateDerivatives(cppfmu::FMIFloat64*,
+                                     std::size_t) const override {}
+  void GetNominalsOfContinuousStates(cppfmu::FMIFloat64*,
+                                     std::size_t) const override {}
+  void GetNumberOfContinuousStates(std::size_t& n) const override { n = 0; }
+  void GetNumberOfEventIndicators(std::size_t& n) const override { n = 0; }
+  void GetEventIndicators(cppfmu::FMIFloat64*, std::size_t) const override {}
+
+  void UpdateDiscreteStates(cppfmu::FMIBoolean* discrete_states_need_update,
+                            cppfmu::FMIBoolean* terminate_simulation,
+                            cppfmu::FMIBoolean* nominal_continuous_states_changed,
+                            cppfmu::FMIBoolean* values_of_continuous_states_changed,
+                            cppfmu::FMIBoolean* next_event_time_defined,
+                            cppfmu::FMIFloat64*) override {
+    *discrete_states_need_update = cppfmu::FMIFalse;
+    *terminate_simulation = cppfmu::FMIFalse;
+    *nominal_continuous_states_changed = cppfmu::FMIFalse;
+    *values_of_continuous_states_changed = cppfmu::FMIFalse;
+    *next_event_time_defined = cppfmu::FMIFalse;
+  }
+
+  void GetFMUstate(fmi3FMUState&) override {}
+  void SetFMUstate(const fmi3FMUState&) override {}
+  void FreeFMUstate(fmi3FMUState&) override {}
+  size_t SerializedFMUstateSize(const fmi3FMUState&) override { return 0; }
+  void SerializeFMUstate(const fmi3FMUState&, fmi3Byte[], size_t) override {}
+  void DeSerializeFMUstate(const fmi3Byte[], size_t, fmi3FMUState&) override {}
+
+ private:
+  // ---------------------------------------------------------------------------
+  // Member Variables
+  // ---------------------------------------------------------------------------
+
+  double time_;     // Current simulation time
+  double input_;    // Input variable
+  double gain_;     // Parameter (tunable)
+  double output_;   // Output variable
+};
+
+}  // namespace
+
+// =============================================================================
+// Factory Function
+// =============================================================================
+// This function is called by the FMI runtime to create an instance of the FMU.
+//
+// Note: The FMI 3.0 version of CPPFMU uses std::unique_ptr directly, unlike the
+// FMI 2.0 version which had cppfmu::AllocateUnique() with a custom Memory
+// allocator. The comment in cppfmu_cs.hpp mentioning AllocateUnique is outdated.
+
+std::unique_ptr<cppfmu::SlaveInstance> CppfmuInstantiateSlave(
+    cppfmu::FMIString /*instance_name*/,
+    cppfmu::FMIString /*fmu_guid*/,
+    cppfmu::FMIString /*fmu_resource_location*/,
+    cppfmu::FMIString /*mime_type*/,
+    cppfmu::FMIFloat64 /*timeout*/,
+    cppfmu::FMIBoolean /*visible*/,
+    cppfmu::FMIBoolean /*interactive*/,
+    const cppfmu::Logger& /*logger*/) {
+  return std::make_unique<TemplateFmu>();
+}


### PR DESCRIPTION
## Summary
- Add a C++ FMU template as a starting point for creating new FMUs
- Uses CPPFMU (FMI 3.0) from PythonFMU3 library
- Includes a simple `input * gain = output` example

## Files
- **template_fmu.cpp**: Well-documented FMU implementation with value reference conventions (time=0, inputs=1-99, params=100-199, outputs=200-299)
- **modelDescription.xml**: FMI 3.0 model description with independent time variable
- **CMakeLists.txt**: Build configuration that fetches CPPFMU from PythonFMU3 via FetchContent
- **build_template_fmu.sh**: Build script for Linux

## Usage
To create a new FMU from this template:
1. Copy the `template_fmu` directory and rename it
2. Update `FMU_MODEL_NAME` in CMakeLists.txt
3. Update `modelIdentifier` and `modelName` in modelDescription.xml
4. Add variables to modelDescription.xml with unique valueReferences
5. Update the `kVr*` constants to match your valueReferences
6. Implement your logic in `DoStep()`

## Test plan
- [x] Build template FMU with `build_template_fmu.sh`
- [x] Validate FMU with FMPy
- [x] Run simulation: `input=5.0 * gain=2.0 = output=10.0` ✓

🤖 Generated with [Claude Code](https://claude.ai/code)
