### PR TITLE
Refactor template FMU to use FMI 3.0 headers directly

### DIFF
--- a/aerosim-dynamics-models/cpp/template_fmu/CMakeLists.txt
+++ b/aerosim-dynamics-models/cpp/template_fmu/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Template FMU CMake Build Configuration
 #
+# Uses the FMI 3.0 C API directly with headers from the official FMI standard:
+# https://github.com/modelica/fmi-standard
+#
 # To create a new FMU from this template:
 # 1. Copy this directory and rename it
 # 2. Update FMU_MODEL_NAME below to match your new FMU name
@@ -17,10 +20,15 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # FMU Configuration - UPDATE THIS FOR YOUR FMU
 # =============================================================================
 set(FMU_MODEL_NAME "template_fmu")
-set(FMU_SOURCE_FILE "template_fmu.cpp")
+
+# Source files: FMU implementation + reusable FMI 3.0 CS stubs
+set(FMU_SOURCES
+    template_fmu.cpp
+    fmi3_cs_stubs.cpp
+)
 
 # =============================================================================
-# Fetch CPPFMU (FMI 3.0) from PythonFMU3 repository
+# Fetch FMI 3.0 Headers from Official FMI Standard Repository
 # =============================================================================
 include(FetchContent)
 
@@ -29,15 +37,15 @@ if(POLICY CMP0169)
 endif()
 
 FetchContent_Declare(
-    pythonfmu3
-    GIT_REPOSITORY https://github.com/stephensmith25/PythonFMU3.git
-    GIT_TAG        master
+    fmi3_headers
+    GIT_REPOSITORY https://github.com/modelica/fmi-standard.git
+    GIT_TAG        v3.0.2
     EXCLUDE_FROM_ALL
 )
-FetchContent_MakeAvailable(pythonfmu3)
+FetchContent_MakeAvailable(fmi3_headers)
 
-set(CPPFMU_SOURCE_DIR "${pythonfmu3_SOURCE_DIR}/pythonfmu3/pythonfmu-export/src")
-message(STATUS "Using CPPFMU sources from: ${CPPFMU_SOURCE_DIR}")
+set(FMI3_INCLUDE_DIR "${fmi3_headers_SOURCE_DIR}/headers")
+message(STATUS "Using FMI 3.0 headers from: ${FMI3_INCLUDE_DIR}")
 
 # =============================================================================
 # Platform Detection
@@ -54,22 +62,12 @@ endif()
 # Build the FMU Shared Library
 # =============================================================================
 add_library(${FMU_MODEL_NAME} SHARED
-    ${FMU_SOURCE_FILE}
-    ${CPPFMU_SOURCE_DIR}/cppfmu/cppfmu_cs.cpp
-    ${CPPFMU_SOURCE_DIR}/cppfmu/fmi_functions.cpp
+    ${FMU_SOURCES}
 )
 
 target_include_directories(${FMU_MODEL_NAME} PRIVATE
-    ${CPPFMU_SOURCE_DIR}
+    ${FMI3_INCLUDE_DIR}
 )
-
-# Suppress MSVC warnings for unimplemented optional FMI 3.0 features in CPPFMU
-if(MSVC)
-    set_source_files_properties(
-        ${CPPFMU_SOURCE_DIR}/cppfmu/fmi_functions.cpp
-        PROPERTIES COMPILE_FLAGS "/wd4297"
-    )
-endif()
 
 set_target_properties(${FMU_MODEL_NAME} PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/binaries/${FMU_PLATFORM}"

--- a/aerosim-dynamics-models/cpp/template_fmu/fmi3_cs_stubs.cpp
+++ b/aerosim-dynamics-models/cpp/template_fmu/fmi3_cs_stubs.cpp
@@ -1,0 +1,601 @@
+// FMI 3.0 Co-Simulation Stubs - Implementation
+//
+// Default implementations for FMI 3.0 functions not typically used in basic
+// Co-Simulation FMUs. These can be linked into any FMU that doesn't need
+// clock handling, state serialization, derivatives, or Model Exchange.
+
+#include "fmi3Functions.h"
+
+extern "C" {
+
+// =============================================================================
+// Debug Logging
+// =============================================================================
+
+fmi3Status fmi3SetDebugLogging(
+    fmi3Instance /*instance*/,
+    fmi3Boolean /*logging_on*/,
+    size_t /*n_categories*/,
+    const fmi3String /*categories*/[]) {
+  return fmi3OK;
+}
+
+// =============================================================================
+// Variable Dependencies
+// =============================================================================
+
+fmi3Status fmi3GetNumberOfVariableDependencies(
+    fmi3Instance /*instance*/,
+    fmi3ValueReference /*value_reference*/,
+    size_t* n_dependencies) {
+  if (n_dependencies) *n_dependencies = 0;
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetVariableDependencies(
+    fmi3Instance /*instance*/,
+    fmi3ValueReference /*dependent*/,
+    size_t /*element_indices_of_dependent*/[],
+    fmi3ValueReference /*independents*/[],
+    size_t /*element_indices_of_independents*/[],
+    fmi3DependencyKind /*dependency_kinds*/[],
+    size_t /*n_dependencies*/) {
+  return fmi3OK;
+}
+
+// =============================================================================
+// Clock Functions (not used in basic Co-Simulation)
+// =============================================================================
+
+fmi3Status fmi3GetClock(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Clock /*values*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetClock(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Clock /*values*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetIntervalDecimal(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Float64 /*intervals*/[],
+    fmi3IntervalQualifier /*qualifiers*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetIntervalFraction(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3UInt64 /*interval_counters*/[],
+    fmi3UInt64 /*resolutions*/[],
+    fmi3IntervalQualifier /*qualifiers*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetIntervalDecimal(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Float64 /*intervals*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetIntervalFraction(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3UInt64 /*interval_counters*/[],
+    const fmi3UInt64 /*resolutions*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetShiftDecimal(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Float64 /*shifts*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetShiftFraction(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3UInt64 /*shift_counters*/[],
+    fmi3UInt64 /*resolutions*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetShiftDecimal(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Float64 /*shifts*/[]) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetShiftFraction(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3UInt64 /*shift_counters*/[],
+    const fmi3UInt64 /*resolutions*/[]) {
+  return fmi3OK;
+}
+
+// =============================================================================
+// Discrete States
+// =============================================================================
+
+fmi3Status fmi3EvaluateDiscreteStates(fmi3Instance /*instance*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3UpdateDiscreteStates(
+    fmi3Instance /*instance*/,
+    fmi3Boolean* discrete_states_need_update,
+    fmi3Boolean* terminate_simulation,
+    fmi3Boolean* nominals_of_continuous_states_changed,
+    fmi3Boolean* values_of_continuous_states_changed,
+    fmi3Boolean* next_event_time_defined,
+    fmi3Float64* next_event_time) {
+  if (discrete_states_need_update) *discrete_states_need_update = fmi3False;
+  if (terminate_simulation) *terminate_simulation = fmi3False;
+  if (nominals_of_continuous_states_changed)
+    *nominals_of_continuous_states_changed = fmi3False;
+  if (values_of_continuous_states_changed)
+    *values_of_continuous_states_changed = fmi3False;
+  if (next_event_time_defined) *next_event_time_defined = fmi3False;
+  if (next_event_time) *next_event_time = 0.0;
+  return fmi3OK;
+}
+
+// =============================================================================
+// FMU State Serialization (not supported)
+// =============================================================================
+
+fmi3Status fmi3GetFMUState(
+    fmi3Instance /*instance*/,
+    fmi3FMUState* /*fmu_state*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3SetFMUState(
+    fmi3Instance /*instance*/,
+    fmi3FMUState /*fmu_state*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3FreeFMUState(
+    fmi3Instance /*instance*/,
+    fmi3FMUState* /*fmu_state*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3SerializedFMUStateSize(
+    fmi3Instance /*instance*/,
+    fmi3FMUState /*fmu_state*/,
+    size_t* /*size*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3SerializeFMUState(
+    fmi3Instance /*instance*/,
+    fmi3FMUState /*fmu_state*/,
+    fmi3Byte /*serialized_state*/[],
+    size_t /*size*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3DeserializeFMUState(
+    fmi3Instance /*instance*/,
+    const fmi3Byte /*serialized_state*/[],
+    size_t /*size*/,
+    fmi3FMUState* /*fmu_state*/) {
+  return fmi3Error;
+}
+
+// =============================================================================
+// Directional Derivatives (not supported)
+// =============================================================================
+
+fmi3Status fmi3GetDirectionalDerivative(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*unknowns*/[],
+    size_t /*n_unknowns*/,
+    const fmi3ValueReference /*knowns*/[],
+    size_t /*n_knowns*/,
+    const fmi3Float64 /*seed*/[],
+    size_t /*n_seed*/,
+    fmi3Float64 /*sensitivity*/[],
+    size_t /*n_sensitivity*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3GetAdjointDerivative(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*unknowns*/[],
+    size_t /*n_unknowns*/,
+    const fmi3ValueReference /*knowns*/[],
+    size_t /*n_knowns*/,
+    const fmi3Float64 /*seed*/[],
+    size_t /*n_seed*/,
+    fmi3Float64 /*sensitivity*/[],
+    size_t /*n_sensitivity*/) {
+  return fmi3Error;
+}
+
+fmi3Status fmi3GetOutputDerivatives(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Int32 /*orders*/[],
+    fmi3Float64 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;
+}
+
+// =============================================================================
+// Co-Simulation State Transitions
+// =============================================================================
+
+fmi3Status fmi3EnterStepMode(fmi3Instance /*instance*/) {
+  return fmi3OK;
+}
+
+// =============================================================================
+// Model Exchange Functions (not supported for Co-Simulation FMUs)
+// =============================================================================
+
+fmi3Instance fmi3InstantiateModelExchange(
+    fmi3String /*instance_name*/,
+    fmi3String /*instantiation_token*/,
+    fmi3String /*resource_path*/,
+    fmi3Boolean /*visible*/,
+    fmi3Boolean /*logging_on*/,
+    fmi3InstanceEnvironment /*instance_environment*/,
+    fmi3LogMessageCallback /*log_message*/) {
+  return nullptr;
+}
+
+fmi3Status fmi3EnterConfigurationMode(fmi3Instance /*instance*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3ExitConfigurationMode(fmi3Instance /*instance*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetTime(fmi3Instance /*instance*/, fmi3Float64 /*time*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetContinuousStates(
+    fmi3Instance /*instance*/,
+    const fmi3Float64 /*continuous_states*/[],
+    size_t /*n_continuous_states*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetContinuousStateDerivatives(
+    fmi3Instance /*instance*/,
+    fmi3Float64 /*derivatives*/[],
+    size_t /*n_continuous_states*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetEventIndicators(
+    fmi3Instance /*instance*/,
+    fmi3Float64 /*event_indicators*/[],
+    size_t /*n_event_indicators*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetContinuousStates(
+    fmi3Instance /*instance*/,
+    fmi3Float64 /*continuous_states*/[],
+    size_t /*n_continuous_states*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetNominalsOfContinuousStates(
+    fmi3Instance /*instance*/,
+    fmi3Float64 /*nominals*/[],
+    size_t /*n_continuous_states*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetNumberOfEventIndicators(
+    fmi3Instance /*instance*/,
+    size_t* n_event_indicators) {
+  if (n_event_indicators) *n_event_indicators = 0;
+  return fmi3OK;
+}
+
+fmi3Status fmi3GetNumberOfContinuousStates(
+    fmi3Instance /*instance*/,
+    size_t* n_continuous_states) {
+  if (n_continuous_states) *n_continuous_states = 0;
+  return fmi3OK;
+}
+
+fmi3Status fmi3EnterContinuousTimeMode(fmi3Instance /*instance*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3EnterEventMode(fmi3Instance /*instance*/) {
+  return fmi3OK;
+}
+
+fmi3Status fmi3CompletedIntegratorStep(
+    fmi3Instance /*instance*/,
+    fmi3Boolean /*no_set_fmu_state_prior_to_current_point*/,
+    fmi3Boolean* enter_event_mode,
+    fmi3Boolean* terminate_simulation) {
+  if (enter_event_mode) *enter_event_mode = fmi3False;
+  if (terminate_simulation) *terminate_simulation = fmi3False;
+  return fmi3OK;
+}
+
+// =============================================================================
+// Scheduled Execution Functions (not supported)
+// =============================================================================
+
+fmi3Instance fmi3InstantiateScheduledExecution(
+    fmi3String /*instance_name*/,
+    fmi3String /*instantiation_token*/,
+    fmi3String /*resource_path*/,
+    fmi3Boolean /*visible*/,
+    fmi3Boolean /*logging_on*/,
+    fmi3InstanceEnvironment /*instance_environment*/,
+    fmi3LogMessageCallback /*log_message*/,
+    fmi3ClockUpdateCallback /*clock_update*/,
+    fmi3LockPreemptionCallback /*lock_preemption*/,
+    fmi3UnlockPreemptionCallback /*unlock_preemption*/) {
+  return nullptr;
+}
+
+fmi3Status fmi3ActivateModelPartition(
+    fmi3Instance /*instance*/,
+    fmi3ValueReference /*clock_reference*/,
+    fmi3Float64 /*activation_time*/) {
+  return fmi3Error;
+}
+
+// =============================================================================
+// Variable Type Getter/Setter Stubs
+// =============================================================================
+// Default implementations for variable types not used by the FMU.
+// These return fmi3Error to indicate the type is not implemented.
+// To implement a type: remove it from here and add your implementation
+// to your FMU's .cpp file using the same pattern as fmi3GetFloat64.
+
+fmi3Status fmi3GetFloat32(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Float32 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Float32 type not implemented
+}
+
+fmi3Status fmi3SetFloat32(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Float32 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Float32 type not implemented
+}
+
+fmi3Status fmi3GetInt8(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Int8 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int8 type not implemented
+}
+
+fmi3Status fmi3SetInt8(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Int8 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int8 type not implemented
+}
+
+fmi3Status fmi3GetUInt8(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3UInt8 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt8 type not implemented
+}
+
+fmi3Status fmi3SetUInt8(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3UInt8 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt8 type not implemented
+}
+
+fmi3Status fmi3GetInt16(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Int16 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int16 type not implemented
+}
+
+fmi3Status fmi3SetInt16(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Int16 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int16 type not implemented
+}
+
+fmi3Status fmi3GetUInt16(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3UInt16 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt16 type not implemented
+}
+
+fmi3Status fmi3SetUInt16(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3UInt16 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt16 type not implemented
+}
+
+fmi3Status fmi3GetInt32(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Int32 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int32 type not implemented
+}
+
+fmi3Status fmi3SetInt32(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Int32 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int32 type not implemented
+}
+
+fmi3Status fmi3GetUInt32(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3UInt32 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt32 type not implemented
+}
+
+fmi3Status fmi3SetUInt32(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3UInt32 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt32 type not implemented
+}
+
+fmi3Status fmi3GetInt64(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Int64 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int64 type not implemented
+}
+
+fmi3Status fmi3SetInt64(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Int64 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Int64 type not implemented
+}
+
+fmi3Status fmi3GetUInt64(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3UInt64 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt64 type not implemented
+}
+
+fmi3Status fmi3SetUInt64(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3UInt64 /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // UInt64 type not implemented
+}
+
+fmi3Status fmi3GetBoolean(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3Boolean /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Boolean type not implemented
+}
+
+fmi3Status fmi3SetBoolean(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3Boolean /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Boolean type not implemented
+}
+
+fmi3Status fmi3GetString(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    fmi3String /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // String type not implemented
+}
+
+fmi3Status fmi3SetString(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const fmi3String /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // String type not implemented
+}
+
+fmi3Status fmi3GetBinary(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    size_t /*sizes*/[],
+    fmi3Binary /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Binary type not implemented
+}
+
+fmi3Status fmi3SetBinary(
+    fmi3Instance /*instance*/,
+    const fmi3ValueReference /*value_references*/[],
+    size_t /*n_value_references*/,
+    const size_t /*sizes*/[],
+    const fmi3Binary /*values*/[],
+    size_t /*n_values*/) {
+  return fmi3Error;  // Binary type not implemented
+}
+
+}  // extern "C"

--- a/aerosim-dynamics-models/cpp/template_fmu/fmi3_cs_stubs.h
+++ b/aerosim-dynamics-models/cpp/template_fmu/fmi3_cs_stubs.h
@@ -1,0 +1,32 @@
+// FMI 3.0 Co-Simulation Stubs
+//
+// Reusable stub implementations for FMI 3.0 functions that are not typically
+// needed for basic Co-Simulation FMUs. Include this header and link against
+// fmi3_cs_stubs.cpp to provide default implementations.
+//
+// These stubs handle:
+// - Clock and interval functions (return fmi3OK, no-op)
+// - FMU state serialization (return fmi3Error, not supported)
+// - Directional derivatives (return fmi3Error, not supported)
+// - Model Exchange functions (return nullptr/fmi3OK, not supported)
+// - Scheduled Execution functions (return fmi3Error, not supported)
+//
+// Your FMU implementation must provide:
+// - fmi3GetVersion()
+// - fmi3InstantiateCoSimulation()
+// - fmi3FreeInstance()
+// - fmi3EnterInitializationMode()
+// - fmi3ExitInitializationMode()
+// - fmi3DoStep()
+// - fmi3Terminate()
+// - fmi3Reset()
+// - Variable getters/setters for your implemented types
+
+#ifndef FMI3_CS_STUBS_H_
+#define FMI3_CS_STUBS_H_
+
+#include "fmi3Functions.h"
+
+// This header declares stubs; implementations are in fmi3_cs_stubs.cpp
+
+#endif  // FMI3_CS_STUBS_H_

--- a/aerosim-dynamics-models/cpp/template_fmu/modelDescription.xml
+++ b/aerosim-dynamics-models/cpp/template_fmu/modelDescription.xml
@@ -71,6 +71,7 @@
             valueReference="1"
             causality="input"
             variability="continuous"
+            initial="exact"
             start="0.0"
             description="Input value to be multiplied by gain"/>
 
@@ -80,6 +81,7 @@
             valueReference="100"
             causality="parameter"
             variability="tunable"
+            initial="exact"
             start="1.0"
             description="Gain multiplier"/>
 

--- a/aerosim-dynamics-models/cpp/template_fmu/modelDescription.xml
+++ b/aerosim-dynamics-models/cpp/template_fmu/modelDescription.xml
@@ -22,7 +22,7 @@
     instantiationToken="{template-fmu-guid}"
     description="Template FMU - multiply input by gain"
     author="AeroSim"
-    generationTool="CPPFMU"
+    generationTool="FMI 3.0 C API"
     variableNamingConvention="structured">
 
     <CoSimulation

--- a/aerosim-dynamics-models/cpp/template_fmu/template_fmu.cpp
+++ b/aerosim-dynamics-models/cpp/template_fmu/template_fmu.cpp
@@ -1,7 +1,7 @@
 // Template FMU - A starting point for creating C++ FMUs
 //
-// Uses the FMI 3.0 version of CPPFMU from pythonfmu3:
-// https://github.com/stephensmith25/PythonFMU3
+// Uses the FMI 3.0 C API directly with headers from:
+// https://github.com/modelica/fmi-standard
 //
 // This template demonstrates the minimal structure needed for a C++ FMU.
 // The example multiplies an input value by a gain parameter to produce an output.
@@ -12,13 +12,15 @@
 // 3. Update modelIdentifier and modelName in modelDescription.xml
 // 4. Add your variables to modelDescription.xml with unique valueReferences
 // 5. Update the kVr* constants to match your valueReferences
-// 6. Implement your logic in DoStep()
+// 6. Implement your logic in fmi3DoStep()
+//
+// This file contains the FMU-specific implementation. Generic FMI 3.0 stubs
+// for clock handling, state serialization, derivatives, and Model Exchange
+// are provided by fmi3_cs_stubs.cpp.
 
-#include "cppfmu/cppfmu_cs.hpp"
+#include "fmi3Functions.h"
 
-#include <cmath>
-
-namespace {
+#include <string>
 
 // =============================================================================
 // Value References
@@ -27,217 +29,247 @@ namespace {
 // Convention: time at 0, inputs 1-99, parameters 100-199, outputs 200-299.
 
 // Independent (time)
-constexpr cppfmu::FMIValueReference kVrTime = 0;
+constexpr fmi3ValueReference kVrTime = 0;
 
 // Inputs
-constexpr cppfmu::FMIValueReference kVrInput = 1;
+constexpr fmi3ValueReference kVrInput = 1;
 
 // Parameters (tunable)
-constexpr cppfmu::FMIValueReference kVrGain = 100;
+constexpr fmi3ValueReference kVrGain = 100;
 
 // Outputs
-constexpr cppfmu::FMIValueReference kVrOutput = 200;
+constexpr fmi3ValueReference kVrOutput = 200;
 
 // =============================================================================
-// FMU Implementation
+// FMU Instance Data
 // =============================================================================
 
-class TemplateFmu : public cppfmu::SlaveInstance {
- public:
-  TemplateFmu()
-      : time_(0.0),
-        input_(0.0),
-        gain_(1.0),
-        output_(0.0) {}
+struct FmuInstance {
+  std::string instance_name;
+  fmi3LogMessageCallback log_message;
+  fmi3InstanceEnvironment instance_environment;
 
-  // ---------------------------------------------------------------------------
-  // Variable Setters - Called by simulation environment to set FMU variables
-  // ---------------------------------------------------------------------------
+  // Model variables
+  fmi3Float64 time = 0.0;
+  fmi3Float64 input = 0.0;
+  fmi3Float64 gain = 1.0;
+  fmi3Float64 output = 0.0;
 
-  void SetFloat64(const cppfmu::FMIValueReference vr[], std::size_t nvr,
-                  const cppfmu::FMIFloat64 value[],
-                  std::size_t /*nValues*/) override {
-    for (std::size_t i = 0; i < nvr; ++i) {
-      switch (vr[i]) {
-        // Note: kVrTime is not settable here - it's set via SetTime()
-        case kVrInput:
-          input_ = value[i];
-          break;
-        case kVrGain:
-          gain_ = value[i];
-          break;
-        // Add cases for additional variables here
-        default:
-          break;
-      }
+  // Helper to log messages
+  void Log(fmi3Status status, const char* category, const char* message) {
+    if (log_message) {
+      log_message(instance_environment, status, category, message);
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // Variable Getters - Called by simulation environment to read FMU variables
-  // ---------------------------------------------------------------------------
-
-  void GetFloat64(const cppfmu::FMIValueReference vr[], std::size_t nvr,
-                  cppfmu::FMIFloat64 value[],
-                  std::size_t /*nValues*/) const override {
-    for (std::size_t i = 0; i < nvr; ++i) {
-      switch (vr[i]) {
-        case kVrTime:
-          value[i] = time_;
-          break;
-        case kVrInput:
-          value[i] = input_;
-          break;
-        case kVrGain:
-          value[i] = gain_;
-          break;
-        case kVrOutput:
-          value[i] = output_;
-          break;
-        // Add cases for additional variables here
-        default:
-          value[i] = 0.0;
-          break;
-      }
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // DoStep - Main simulation step function
-  // ---------------------------------------------------------------------------
-  // This is called each simulation step. Implement your logic here.
-  //
-  // Parameters:
-  //   current_communication_point: Current simulation time
-  //   communication_step_size: Time step size
-  //   new_step: True if this is a new step (not a rollback)
-  //   event_handling_needed: Set to true if events need handling
-  //   terminate_simulation: Set to true to request simulation termination
-  //   early_return: Set to true if returning before step_size elapsed
-  //   end_of_step: Actual end time of the step
-
-  cppfmu::FMIStatus DoStep(cppfmu::FMIFloat64 current_communication_point,
-                           cppfmu::FMIFloat64 communication_step_size,
-                           cppfmu::FMIBoolean /*new_step*/,
-                           cppfmu::FMIBoolean* event_handling_needed,
-                           cppfmu::FMIBoolean* terminate_simulation,
-                           cppfmu::FMIBoolean* early_return,
-                           cppfmu::FMIFloat64& end_of_step) override {
-    // Update time (for Co-Simulation, time advances here, not via SetTime)
-    time_ = current_communication_point + communication_step_size;
-
-    // =========================================================================
-    // YOUR LOGIC HERE
-    // =========================================================================
-    // This example simply multiplies the input by the gain.
-    // Replace this with your actual computation.
-
-    output_ = input_ * gain_;
-
-    // =========================================================================
-    // END OF YOUR LOGIC
-    // =========================================================================
-
-    // Set output flags (typically leave these as-is)
-    *event_handling_needed = cppfmu::FMIFalse;
-    *terminate_simulation = cppfmu::FMIFalse;
-    *early_return = cppfmu::FMIFalse;
-    end_of_step = time_;
-
-    return cppfmu::FMIOK;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Initialization - Compute initial output values
-  // ---------------------------------------------------------------------------
-  // ExitInitializationMode is called after all initial values have been set
-  // but before the first DoStep(). Use this to compute initial outputs.
-
-  void ExitInitializationMode() override {
-    // Compute initial output from initial input and parameter values
-    output_ = input_ * gain_;
-  }
-
-  // ---------------------------------------------------------------------------
-  // Optional: Other initialization methods
-  // ---------------------------------------------------------------------------
-
-  // void SetupExperiment(cppfmu::FMIBoolean tolerance_defined,
-  //                      cppfmu::FMIFloat64 tolerance,
-  //                      cppfmu::FMIFloat64 start_time,
-  //                      cppfmu::FMIBoolean stop_time_defined,
-  //                      cppfmu::FMIFloat64 stop_time) override {}
-
-  // void EnterInitializationMode() override {}
-  // void Terminate() override {}
-  // void Reset() override {}
-
-  // ---------------------------------------------------------------------------
-  // Model Exchange stubs - Required by CPPFMU interface but not called for
-  // Co-Simulation FMUs. For CS, time advances via DoStep(), not SetTime().
-  // ---------------------------------------------------------------------------
-
-  void SetTime(cppfmu::FMIFloat64 time) override { time_ = time; }  // ME only
-  void GetContinuousStates(cppfmu::FMIFloat64*, std::size_t) const override {}
-  void SetContinuousStates(const cppfmu::FMIFloat64*, std::size_t) override {}
-  void GetContinuousStateDerivatives(cppfmu::FMIFloat64*,
-                                     std::size_t) const override {}
-  void GetNominalsOfContinuousStates(cppfmu::FMIFloat64*,
-                                     std::size_t) const override {}
-  void GetNumberOfContinuousStates(std::size_t& n) const override { n = 0; }
-  void GetNumberOfEventIndicators(std::size_t& n) const override { n = 0; }
-  void GetEventIndicators(cppfmu::FMIFloat64*, std::size_t) const override {}
-
-  void UpdateDiscreteStates(cppfmu::FMIBoolean* discrete_states_need_update,
-                            cppfmu::FMIBoolean* terminate_simulation,
-                            cppfmu::FMIBoolean* nominal_continuous_states_changed,
-                            cppfmu::FMIBoolean* values_of_continuous_states_changed,
-                            cppfmu::FMIBoolean* next_event_time_defined,
-                            cppfmu::FMIFloat64*) override {
-    *discrete_states_need_update = cppfmu::FMIFalse;
-    *terminate_simulation = cppfmu::FMIFalse;
-    *nominal_continuous_states_changed = cppfmu::FMIFalse;
-    *values_of_continuous_states_changed = cppfmu::FMIFalse;
-    *next_event_time_defined = cppfmu::FMIFalse;
-  }
-
-  void GetFMUstate(fmi3FMUState&) override {}
-  void SetFMUstate(const fmi3FMUState&) override {}
-  void FreeFMUstate(fmi3FMUState&) override {}
-  size_t SerializedFMUstateSize(const fmi3FMUState&) override { return 0; }
-  void SerializeFMUstate(const fmi3FMUState&, fmi3Byte[], size_t) override {}
-  void DeSerializeFMUstate(const fmi3Byte[], size_t, fmi3FMUState&) override {}
-
- private:
-  // ---------------------------------------------------------------------------
-  // Member Variables
-  // ---------------------------------------------------------------------------
-
-  double time_;     // Current simulation time
-  double input_;    // Input variable
-  double gain_;     // Parameter (tunable)
-  double output_;   // Output variable
 };
 
-}  // namespace
-
 // =============================================================================
-// Factory Function
+// FMI 3.0 Core Functions
 // =============================================================================
-// This function is called by the FMI runtime to create an instance of the FMU.
-//
-// Note: The FMI 3.0 version of CPPFMU uses std::unique_ptr directly, unlike the
-// FMI 2.0 version which had cppfmu::AllocateUnique() with a custom Memory
-// allocator. The comment in cppfmu_cs.hpp mentioning AllocateUnique is outdated.
 
-std::unique_ptr<cppfmu::SlaveInstance> CppfmuInstantiateSlave(
-    cppfmu::FMIString /*instance_name*/,
-    cppfmu::FMIString /*fmu_guid*/,
-    cppfmu::FMIString /*fmu_resource_location*/,
-    cppfmu::FMIString /*mime_type*/,
-    cppfmu::FMIFloat64 /*timeout*/,
-    cppfmu::FMIBoolean /*visible*/,
-    cppfmu::FMIBoolean /*interactive*/,
-    const cppfmu::Logger& /*logger*/) {
-  return std::make_unique<TemplateFmu>();
+extern "C" {
+
+// -----------------------------------------------------------------------------
+// Version
+// -----------------------------------------------------------------------------
+
+const char* fmi3GetVersion() {
+  return "3.0";
 }
+
+// -----------------------------------------------------------------------------
+// Instance Creation and Destruction
+// -----------------------------------------------------------------------------
+
+fmi3Instance fmi3InstantiateCoSimulation(
+    fmi3String instance_name,
+    fmi3String /*instantiation_token*/,
+    fmi3String /*resource_path*/,
+    fmi3Boolean /*visible*/,
+    fmi3Boolean /*logging_on*/,
+    fmi3Boolean /*event_mode_used*/,
+    fmi3Boolean /*early_return_allowed*/,
+    const fmi3ValueReference /*required_intermediate_variables*/[],
+    size_t /*n_required_intermediate_variables*/,
+    fmi3InstanceEnvironment instance_environment,
+    fmi3LogMessageCallback log_message,
+    fmi3IntermediateUpdateCallback /*intermediate_update*/) {
+  auto* instance = new FmuInstance();
+  instance->instance_name = instance_name ? instance_name : "";
+  instance->log_message = log_message;
+  instance->instance_environment = instance_environment;
+  return instance;
+}
+
+void fmi3FreeInstance(fmi3Instance instance) {
+  delete static_cast<FmuInstance*>(instance);
+}
+
+// -----------------------------------------------------------------------------
+// Initialization
+// -----------------------------------------------------------------------------
+
+fmi3Status fmi3EnterInitializationMode(
+    fmi3Instance instance,
+    fmi3Boolean /*tolerance_defined*/,
+    fmi3Float64 /*tolerance*/,
+    fmi3Float64 start_time,
+    fmi3Boolean /*stop_time_defined*/,
+    fmi3Float64 /*stop_time*/) {
+  if (!instance) return fmi3Error;
+  auto* fmu = static_cast<FmuInstance*>(instance);
+  fmu->time = start_time;
+  return fmi3OK;
+}
+
+fmi3Status fmi3ExitInitializationMode(fmi3Instance instance) {
+  if (!instance) return fmi3Error;
+  auto* fmu = static_cast<FmuInstance*>(instance);
+
+  // Compute initial output from initial input and parameter values
+  fmu->output = fmu->input * fmu->gain;
+
+  return fmi3OK;
+}
+
+// -----------------------------------------------------------------------------
+// Simulation Step
+// -----------------------------------------------------------------------------
+
+fmi3Status fmi3DoStep(
+    fmi3Instance instance,
+    fmi3Float64 current_communication_point,
+    fmi3Float64 communication_step_size,
+    fmi3Boolean /*no_set_fmu_state_prior_to_current_point*/,
+    fmi3Boolean* event_handling_needed,
+    fmi3Boolean* terminate_simulation,
+    fmi3Boolean* early_return,
+    fmi3Float64* last_successful_time) {
+  if (!instance) return fmi3Error;
+
+  auto* fmu = static_cast<FmuInstance*>(instance);
+
+  // Update time
+  fmu->time = current_communication_point + communication_step_size;
+
+  // ===========================================================================
+  // YOUR LOGIC HERE
+  // ===========================================================================
+  // This example simply multiplies the input by the gain.
+  // Replace this with your actual computation.
+
+  fmu->output = fmu->input * fmu->gain;
+
+  // ===========================================================================
+  // END OF YOUR LOGIC
+  // ===========================================================================
+
+  // Set output flags
+  if (event_handling_needed) *event_handling_needed = fmi3False;
+  if (terminate_simulation) *terminate_simulation = fmi3False;
+  if (early_return) *early_return = fmi3False;
+  if (last_successful_time) *last_successful_time = fmu->time;
+
+  return fmi3OK;
+}
+
+// -----------------------------------------------------------------------------
+// Termination and Reset
+// -----------------------------------------------------------------------------
+
+fmi3Status fmi3Terminate(fmi3Instance instance) {
+  if (!instance) return fmi3Error;
+  return fmi3OK;
+}
+
+fmi3Status fmi3Reset(fmi3Instance instance) {
+  if (!instance) return fmi3Error;
+  auto* fmu = static_cast<FmuInstance*>(instance);
+  fmu->time = 0.0;
+  fmu->input = 0.0;
+  fmu->gain = 1.0;
+  fmu->output = 0.0;
+  return fmi3OK;
+}
+
+// =============================================================================
+// Variable Getters and Setters
+// =============================================================================
+// Implement getters/setters for the variable types used by your FMU.
+// The scaffolding below shows the pattern for each type.
+// Add cases to the switch statements for your value references.
+
+// -----------------------------------------------------------------------------
+// Float64 (implemented for this template)
+// -----------------------------------------------------------------------------
+
+fmi3Status fmi3GetFloat64(
+    fmi3Instance instance,
+    const fmi3ValueReference value_references[],
+    size_t n_value_references,
+    fmi3Float64 values[],
+    size_t n_values) {
+  if (!instance) return fmi3Error;
+  if (n_values < n_value_references) return fmi3Error;
+
+  auto* fmu = static_cast<FmuInstance*>(instance);
+
+  for (size_t i = 0; i < n_value_references; ++i) {
+    switch (value_references[i]) {
+      case kVrTime:
+        values[i] = fmu->time;
+        break;
+      case kVrInput:
+        values[i] = fmu->input;
+        break;
+      case kVrGain:
+        values[i] = fmu->gain;
+        break;
+      case kVrOutput:
+        values[i] = fmu->output;
+        break;
+      // Add cases for additional Float64 variables here
+      default:
+        values[i] = 0.0;
+        break;
+    }
+  }
+  return fmi3OK;
+}
+
+fmi3Status fmi3SetFloat64(
+    fmi3Instance instance,
+    const fmi3ValueReference value_references[],
+    size_t n_value_references,
+    const fmi3Float64 values[],
+    size_t n_values) {
+  if (!instance) return fmi3Error;
+  if (n_values < n_value_references) return fmi3Error;
+
+  auto* fmu = static_cast<FmuInstance*>(instance);
+
+  for (size_t i = 0; i < n_value_references; ++i) {
+    switch (value_references[i]) {
+      // Note: kVrTime is not settable - time advances via fmi3DoStep
+      case kVrInput:
+        fmu->input = values[i];
+        break;
+      case kVrGain:
+        fmu->gain = values[i];
+        break;
+      // Add cases for additional Float64 variables here
+      default:
+        break;
+    }
+  }
+  return fmi3OK;
+}
+
+// -----------------------------------------------------------------------------
+// Other Variable Types
+// -----------------------------------------------------------------------------
+// To implement additional variable types (Int32, Boolean, String, etc.):
+// 1. Remove the stub from fmi3_cs_stubs.cpp for that type
+// 2. Add your implementation here following the Float64 pattern above
+
+}  // extern "C"


### PR DESCRIPTION
## Summary
- Refactor template FMU to use official FMI 3.0 C API headers directly instead of CPPFMU wrapper library
- Fetch headers from modelica/fmi-standard v3.0.2 repository via CMake FetchContent
- Separate reusable FMI 3.0 Co-Simulation stubs into dedicated module for easier FMU creation

## Changes
- **CMakeLists.txt**: Replace PythonFMU3/CPPFMU dependency with official FMI 3.0 headers from https://github.com/modelica/fmi-standard
- **template_fmu.cpp**: Implement FMI 3.0 C functions directly (fmi3InstantiateCoSimulation, fmi3DoStep, fmi3GetFloat64, etc.)
- **fmi3_cs_stubs.cpp** (new): Reusable stubs for FMI 3.0 functions not needed in basic Co-Simulation (clock handling, state serialization, derivatives, Model Exchange, Scheduled Execution, unused variable types)
- **fmi3_cs_stubs.h** (new): Header documenting which functions are provided by stubs vs must be implemented
- **modelDescription.xml**: Update generationTool to "FMI 3.0 C API", add explicit `initial="exact"` to settable variables

## Benefits
- No external C++ wrapper library dependency - just official FMI 3.0 headers
- Clear separation between FMU-specific code and generic FMI boilerplate
- Stubs module can be reused when creating new FMUs
- Easier to understand FMI 3.0 API usage without abstraction layer

## Test plan
- [x] Build template FMU: `./build_template_fmu.sh`
- [x] Validate FMU: `fmpy validate examples/fmu/template_fmu.fmu`
- [x] Run simulation test:
```
fmpy simulate examples/fmu/template_fmu.fmu --start-values input 5.0 gain 2.0 --output-variables output --output-file /dev/stdout | tail -1
```
(expect `1.0,10.0` showing time=1.0, output=10.0)