### PR TITLE
Update Windows batch scripts for building FMUs

### DIFF
--- a/aerosim-dynamics-models/build_template_fmu.bat
+++ b/aerosim-dynamics-models/build_template_fmu.bat
@@ -1,11 +1,11 @@
 @echo off
-REM Build script for C++ eVTOL Effectors FMU (Windows)
+REM Build script for Template FMU
 
 set SCRIPT_DIR=%~dp0
-set CPP_DIR=%SCRIPT_DIR%cpp\evtol_effectors
+set CPP_DIR=%SCRIPT_DIR%cpp\template_fmu
 set BUILD_DIR=%CPP_DIR%\build
 
-echo Building C++ eVTOL Effectors FMU...
+echo Building Template FMU...
 
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
 pushd "%BUILD_DIR%"
@@ -24,9 +24,9 @@ if %ERRORLEVEL% neq 0 (
     exit /b 1
 )
 
-if exist "%BUILD_DIR%\evtol_effectors_fmu_model_cpp.fmu" (
-    copy "%BUILD_DIR%\evtol_effectors_fmu_model_cpp.fmu" "%SCRIPT_DIR%..\examples\fmu\" >nul
-    echo Built and copied evtol_effectors_fmu_model_cpp.fmu to ..\examples\fmu
+if exist "%BUILD_DIR%\template_fmu.fmu" (
+    copy "%BUILD_DIR%\template_fmu.fmu" "%SCRIPT_DIR%..\examples\fmu\" >nul
+    echo Built and copied template_fmu.fmu to ..\examples\fmu
     popd
 ) else (
     echo Build failed - FMU file not found


### PR DESCRIPTION
## Summary

Adds Windows batch file scripts for building FMUs with proper error handling and directory management.

## Changes

### New Files
- **build_template_fmu.bat** - Windows build script for the template FMU, equivalent to the existing `build_template_fmu.sh` shell script

### Modified Files
- **build_evtol_effectors_fmu_cpp.bat** - Improved with better error handling and directory management to match the new template FMU script

## Key Improvements

1. **Proper directory management** - Uses `pushd`/`popd` instead of `cd` to ensure the script always returns to the original directory, regardless of success or failure

2. **Error handling** - Added `%ERRORLEVEL%` checks after cmake configuration and build steps, with proper cleanup (`popd`) before exiting on errors

3. **Windows compatibility** - Removed `-DCMAKE_BUILD_TYPE=Release` flag from cmake configuration to avoid warnings when using multi-configuration generators (Visual Studio). The build type is correctly specified via `--config Release` in the build step.

4. **Consistent pattern** - Both scripts now follow the same structure and best practices for Windows batch files

## Technical Details

- Uses `pushd` to save the current directory before changing to the build directory
- Calls `popd` at every exit point (success and all failure paths) to restore the original directory
- Suppresses copy output with `>nul` for cleaner console output
- Multi-config generators on Windows handle Debug/Release configurations at build time, not configuration time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
