### PR TITLE
Middleware benchmarking

### DIFF
--- a/aerosim-data/examples/latency_benchmark.rs
+++ b/aerosim-data/examples/latency_benchmark.rs
@@ -1,0 +1,806 @@
+//! Middleware Publish-Subscribe Latency Benchmark
+//!
+//! This example benchmarks round-trip latency between two simulated nodes using middleware.
+//! Node A publishes messages with timestamps to a forward topic, Node B receives them and echoes
+//! back to a return topic, and Node A measures the round-trip latency.
+//!
+//! Run with:
+//!   cargo run --example latency_benchmark --features zenoh -- zenoh
+//!   cargo run --example latency_benchmark --features kafka -- kafka
+//!   cargo run --example latency_benchmark --features default -- zenoh  # or kafka
+
+use std::env;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use aerosim_data::middleware::{Metadata, Middleware, MiddlewareRaw, MiddlewareRegistry, Serializer};
+use aerosim_data::types::JsonData;
+
+/// Latency measurement result (in milliseconds)
+#[derive(Debug, Clone)]
+struct LatencyMeasurement {
+    forward_latency_ms: f64,
+    return_latency_ms: f64,
+    roundtrip_latency_ms: f64,
+}
+
+/// Detailed latency measurement with serialization breakdown (in milliseconds)
+#[derive(Debug, Clone)]
+struct DetailedLatencyMeasurement {
+    // Forward leg breakdown
+    forward_serialize_ms: f64,
+    forward_transport_ms: f64,
+    forward_deserialize_ms: f64,
+    forward_total_ms: f64,
+    // Return leg breakdown
+    return_serialize_ms: f64,
+    return_transport_ms: f64,
+    return_deserialize_ms: f64,
+    return_total_ms: f64,
+    // Round-trip total
+    roundtrip_total_ms: f64,
+}
+
+/// Statistics calculator
+struct Stats {
+    values: Vec<f64>,
+}
+
+impl Stats {
+    fn new(values: Vec<f64>) -> Self {
+        Self { values }
+    }
+
+    fn mean(&self) -> f64 {
+        if self.values.is_empty() {
+            return 0.0;
+        }
+        self.values.iter().sum::<f64>() / self.values.len() as f64
+    }
+
+    fn median(&self) -> f64 {
+        if self.values.is_empty() {
+            return 0.0;
+        }
+        let mut sorted = self.values.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let mid = sorted.len() / 2;
+        if sorted.len() % 2 == 0 {
+            (sorted[mid - 1] + sorted[mid]) / 2.0
+        } else {
+            sorted[mid]
+        }
+    }
+
+    fn min(&self) -> f64 {
+        self.values.iter().cloned().fold(f64::INFINITY, f64::min)
+    }
+
+    fn max(&self) -> f64 {
+        self.values
+            .iter()
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max)
+    }
+
+    fn std_dev(&self) -> f64 {
+        if self.values.len() < 2 {
+            return 0.0;
+        }
+        let mean = self.mean();
+        let variance = self.values.iter().map(|x| (x - mean).powi(2)).sum::<f64>()
+            / (self.values.len() - 1) as f64;
+        variance.sqrt()
+    }
+}
+
+fn print_stats(title: &str, values: &[f64], unit: &str) {
+    let stats = Stats::new(values.to_vec());
+    println!("\n{}:", title);
+    println!("  Samples: {}", values.len());
+    println!("  Average: {:.3} {}", stats.mean(), unit);
+    println!("  Median:  {:.3} {}", stats.median(), unit);
+    println!("  Min:     {:.3} {}", stats.min(), unit);
+    println!("  Max:     {:.3} {}", stats.max(), unit);
+    if values.len() > 1 {
+        println!("  Std Dev: {:.3} {}", stats.std_dev(), unit);
+    }
+}
+
+fn print_stats_inline(title: &str, values: &[f64], indent: &str) {
+    if values.is_empty() {
+        return;
+    }
+    let stats = Stats::new(values.to_vec());
+    println!("{}{}:", indent, title);
+    println!("{}  Average: {:.3} ms", indent, stats.mean());
+    println!("{}  Median:  {:.3} ms", indent, stats.median());
+    println!("{}  Min:     {:.3} ms", indent, stats.min());
+    println!("{}  Max:     {:.3} ms", indent, stats.max());
+}
+
+fn print_benchmark_results(title: &str, measurements: &[LatencyMeasurement]) {
+    println!("\n{}", "=".repeat(60));
+    println!("{}", title);
+    println!("{}", "=".repeat(60));
+
+    let forward: Vec<f64> = measurements.iter().map(|m| m.forward_latency_ms).collect();
+    let return_: Vec<f64> = measurements.iter().map(|m| m.return_latency_ms).collect();
+    let roundtrip: Vec<f64> = measurements.iter().map(|m| m.roundtrip_latency_ms).collect();
+
+    print_stats("Forward Latency (Node A -> Node B)", &forward, "ms");
+    print_stats("Return Latency (Node B -> Node A)", &return_, "ms");
+    print_stats(
+        "Round-Trip Latency (Node A -> Node B -> Node A)",
+        &roundtrip,
+        "ms",
+    );
+
+    println!("\n{}", "=".repeat(60));
+}
+
+fn print_detailed_benchmark_results(title: &str, measurements: &[DetailedLatencyMeasurement]) {
+    println!("\n{}", "=".repeat(70));
+    println!("{}", title);
+    println!("{}", "=".repeat(70));
+    println!("Samples: {}", measurements.len());
+
+    if measurements.is_empty() {
+        println!("No measurements collected");
+        println!("{}", "=".repeat(70));
+        return;
+    }
+
+    // Forward leg
+    let forward_serialize: Vec<f64> = measurements.iter().map(|m| m.forward_serialize_ms).collect();
+    let forward_transport: Vec<f64> = measurements.iter().map(|m| m.forward_transport_ms).collect();
+    let forward_deserialize: Vec<f64> = measurements.iter().map(|m| m.forward_deserialize_ms).collect();
+    let forward_total: Vec<f64> = measurements.iter().map(|m| m.forward_total_ms).collect();
+
+    println!(
+        "\nForward Leg (Node A -> Node B): {:.3} ms avg",
+        Stats::new(forward_total.clone()).mean()
+    );
+    print_stats_inline("Serialize (Node A)", &forward_serialize, "  ");
+    print_stats_inline("Transport", &forward_transport, "  ");
+    print_stats_inline("Deserialize (Node B)", &forward_deserialize, "  ");
+
+    // Return leg
+    let return_serialize: Vec<f64> = measurements.iter().map(|m| m.return_serialize_ms).collect();
+    let return_transport: Vec<f64> = measurements.iter().map(|m| m.return_transport_ms).collect();
+    let return_deserialize: Vec<f64> = measurements.iter().map(|m| m.return_deserialize_ms).collect();
+    let return_total: Vec<f64> = measurements.iter().map(|m| m.return_total_ms).collect();
+
+    println!(
+        "\nReturn Leg (Node B -> Node A): {:.3} ms avg",
+        Stats::new(return_total.clone()).mean()
+    );
+    print_stats_inline("Serialize (Node B)", &return_serialize, "  ");
+    print_stats_inline("Transport", &return_transport, "  ");
+    print_stats_inline("Deserialize (Node A)", &return_deserialize, "  ");
+
+    // Round-trip summary
+    let roundtrip_total: Vec<f64> = measurements.iter().map(|m| m.roundtrip_total_ms).collect();
+    println!(
+        "\nRound-Trip Total: {:.3} ms avg",
+        Stats::new(roundtrip_total).mean()
+    );
+
+    // Breakdown summary
+    let total_serialize = Stats::new(forward_serialize.clone()).mean() + Stats::new(return_serialize.clone()).mean();
+    let total_transport = Stats::new(forward_transport.clone()).mean() + Stats::new(return_transport.clone()).mean();
+    let total_deserialize = Stats::new(forward_deserialize.clone()).mean() + Stats::new(return_deserialize.clone()).mean();
+    let total_time = total_serialize + total_transport + total_deserialize;
+
+    if total_time > 0.0 {
+        println!("\n  Breakdown (averages):");
+        println!(
+            "    Total Serialize:   {:.3} ms ({:.1}%)",
+            total_serialize,
+            100.0 * total_serialize / total_time
+        );
+        println!(
+            "    Total Transport:   {:.3} ms ({:.1}%)",
+            total_transport,
+            100.0 * total_transport / total_time
+        );
+        println!(
+            "    Total Deserialize: {:.3} ms ({:.1}%)",
+            total_deserialize,
+            100.0 * total_deserialize / total_time
+        );
+    }
+
+    println!("\n{}", "=".repeat(70));
+}
+
+/// Message passed through channel from forward subscriber to echo publisher
+#[derive(Debug)]
+struct EchoRequest {
+    msg_id: u64,
+    original_send_time_nanos: u64,
+    node_b_receive_time_nanos: u64,
+}
+
+/// Detailed echo request with serialization timing
+#[derive(Debug)]
+struct DetailedEchoRequest {
+    msg_id: u64,
+    original_send_time_nanos: u64,
+    send_after_serialize_nanos: u64,
+    node_b_receive_time_nanos: u64,
+    node_b_deserialize_done_nanos: u64,
+}
+
+async fn run_benchmark(
+    transport_name: &str,
+    num_messages: usize,
+    warmup_messages: usize,
+    payload_size: usize,
+    topic_prefix: &str,
+) -> Vec<LatencyMeasurement> {
+    let registry = MiddlewareRegistry::new();
+    let middleware = registry
+        .get(transport_name)
+        .unwrap_or_else(|| panic!("{} middleware not available", transport_name));
+
+    // Use dash separator for topics (works with both Zenoh and Kafka)
+    let forward_topic = format!("{}-forward", topic_prefix);
+    let return_topic = format!("{}-return", topic_prefix);
+
+    // Reference time for consistent nanosecond measurements
+    let reference_time = Instant::now();
+
+    // Channels for communication
+    let (echo_tx, mut echo_rx) = mpsc::channel::<EchoRequest>(1024);
+    let (measurement_tx, mut measurement_rx) = mpsc::channel::<LatencyMeasurement>(1024);
+
+    // Counters
+    let received_count = Arc::new(AtomicUsize::new(0));
+    let total_expected = num_messages + warmup_messages;
+    let done = Arc::new(AtomicBool::new(false));
+
+    // Clone reference time for callbacks
+    let ref_time_b = reference_time;
+
+    // Node B callback: receives forward message, sends echo request through channel
+    middleware
+        .subscribe(
+            &forward_topic,
+            Box::new(move |data: JsonData, _metadata: Metadata| {
+                let receive_time_nanos = ref_time_b.elapsed().as_nanos() as u64;
+
+                let json_data = data.get_data().unwrap();
+                let msg_id = json_data["msg_id"].as_u64().unwrap();
+                let original_send_time_nanos = json_data["send_time_nanos"].as_u64().unwrap();
+
+                let _ = echo_tx.try_send(EchoRequest {
+                    msg_id,
+                    original_send_time_nanos,
+                    node_b_receive_time_nanos: receive_time_nanos,
+                });
+
+                Ok(())
+            }),
+        )
+        .await
+        .expect("Failed to subscribe to forward topic");
+
+    // Node A callback: receives echo and calculates latencies
+    let ref_time_a = reference_time;
+    let warmup = warmup_messages;
+    let received_count_clone = received_count.clone();
+
+    middleware
+        .subscribe(
+            &return_topic,
+            Box::new(move |data: JsonData, _metadata: Metadata| {
+                let receive_time_nanos = ref_time_a.elapsed().as_nanos() as u64;
+
+                let json_data = data.get_data().unwrap();
+                let msg_id = json_data["msg_id"].as_u64().unwrap() as usize;
+                let original_send_time_nanos = json_data["original_send_time_nanos"].as_u64().unwrap();
+                let node_b_receive_time_nanos = json_data["node_b_receive_time_nanos"].as_u64().unwrap();
+                let node_b_send_time_nanos = json_data["node_b_send_time_nanos"].as_u64().unwrap();
+
+                // Skip warmup messages
+                if msg_id >= warmup {
+                    let forward_latency_ms =
+                        (node_b_receive_time_nanos - original_send_time_nanos) as f64 / 1_000_000.0;
+                    let return_latency_ms =
+                        (receive_time_nanos - node_b_send_time_nanos) as f64 / 1_000_000.0;
+                    let roundtrip_latency_ms =
+                        (receive_time_nanos - original_send_time_nanos) as f64 / 1_000_000.0;
+
+                    let _ = measurement_tx.try_send(LatencyMeasurement {
+                        forward_latency_ms,
+                        return_latency_ms,
+                        roundtrip_latency_ms,
+                    });
+                }
+
+                received_count_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+        )
+        .await
+        .expect("Failed to subscribe to return topic");
+
+    // Allow subscriptions to establish
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // Spawn echo publisher task (Node B's echo response)
+    let middleware_echo = middleware.clone();
+    let return_topic_echo = return_topic.clone();
+    let ref_time_echo = reference_time;
+    let done_clone = done.clone();
+
+    let echo_task = tokio::spawn(async move {
+        while let Some(req) = echo_rx.recv().await {
+            if done_clone.load(Ordering::SeqCst) {
+                break;
+            }
+
+            let node_b_send_time_nanos = ref_time_echo.elapsed().as_nanos() as u64;
+
+            let return_msg = json!({
+                "msg_id": req.msg_id,
+                "original_send_time_nanos": req.original_send_time_nanos,
+                "node_b_receive_time_nanos": req.node_b_receive_time_nanos,
+                "node_b_send_time_nanos": node_b_send_time_nanos,
+            });
+
+            let return_data = JsonData::new(return_msg);
+            let _ = middleware_echo
+                .publish(&return_topic_echo, &return_data, None)
+                .await;
+        }
+    });
+
+    // Generate payload
+    let payload = "x".repeat(payload_size);
+
+    // Send messages
+    let total_messages = num_messages + warmup_messages;
+    for i in 0..total_messages {
+        let send_time_nanos = reference_time.elapsed().as_nanos() as u64;
+
+        let message = json!({
+            "msg_id": i,
+            "send_time_nanos": send_time_nanos,
+            "payload": payload,
+        });
+
+        let data = JsonData::new(message);
+        middleware
+            .publish(&forward_topic, &data, None)
+            .await
+            .expect("Failed to publish forward message");
+
+        // Small delay between messages
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Wait for all messages with timeout
+    let timeout = Duration::from_secs(120);
+    let start = Instant::now();
+    while received_count.load(Ordering::SeqCst) < total_expected {
+        if start.elapsed() > timeout {
+            eprintln!(
+                "Warning: Timeout waiting for messages. Received {}/{}",
+                received_count.load(Ordering::SeqCst),
+                total_expected
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Signal done and cleanup
+    done.store(true, Ordering::SeqCst);
+
+    // Wait for echo task to finish
+    let _ = tokio::time::timeout(Duration::from_secs(2), echo_task).await;
+
+    // Collect measurements
+    let mut measurements = Vec::new();
+    while let Ok(m) = measurement_rx.try_recv() {
+        measurements.push(m);
+    }
+
+    measurements
+}
+
+async fn run_detailed_benchmark(
+    transport_name: &str,
+    num_messages: usize,
+    warmup_messages: usize,
+    payload_size: usize,
+    topic_prefix: &str,
+) -> Vec<DetailedLatencyMeasurement> {
+    let registry = MiddlewareRegistry::new();
+    let middleware = registry
+        .get(transport_name)
+        .unwrap_or_else(|| panic!("{} middleware not available", transport_name));
+    let serializer = middleware.get_serializer();
+
+    // Use dash separator for topics (works with both Zenoh and Kafka)
+    let forward_topic = format!("{}-forward", topic_prefix);
+    let return_topic = format!("{}-return", topic_prefix);
+    let type_name = "aerosim::types::JsonData";
+
+    // Reference time for consistent nanosecond measurements
+    let reference_time = Instant::now();
+
+    // Channels for communication
+    let (echo_tx, mut echo_rx) = mpsc::channel::<DetailedEchoRequest>(1024);
+    let (measurement_tx, mut measurement_rx) = mpsc::channel::<DetailedLatencyMeasurement>(1024);
+    let (forward_serialize_tx, forward_serialize_rx) = mpsc::channel::<f64>(1024);
+    let forward_serialize_rx = Arc::new(std::sync::Mutex::new(forward_serialize_rx));
+
+    // Counters
+    let received_count = Arc::new(AtomicUsize::new(0));
+    let total_expected = num_messages + warmup_messages;
+    let done = Arc::new(AtomicBool::new(false));
+
+    // Clone middleware for callbacks (get serializer inside each callback)
+    let middleware_b = middleware.clone();
+    let ref_time_b = reference_time;
+
+    // Node B callback: receives forward message with detailed timing
+    middleware
+        .subscribe_raw(
+            type_name,
+            &forward_topic,
+            Box::new(move |payload: &[u8]| {
+                let receive_time_nanos = ref_time_b.elapsed().as_nanos() as u64;
+
+                // Deserialize and measure time
+                let serializer_b = middleware_b.get_serializer();
+                let (_metadata, data): (Metadata, JsonData) = serializer_b
+                    .deserialize_message(payload)
+                    .expect("Failed to deserialize forward message");
+                let deserialize_done_nanos = ref_time_b.elapsed().as_nanos() as u64;
+
+                let json_data = data.get_data().unwrap();
+                let msg_id = json_data["msg_id"].as_u64().unwrap();
+                let original_send_time_nanos = json_data["send_time_nanos"].as_u64().unwrap();
+                let send_after_serialize_nanos = json_data["send_after_serialize_nanos"].as_u64().unwrap_or(original_send_time_nanos);
+
+                let _ = echo_tx.try_send(DetailedEchoRequest {
+                    msg_id,
+                    original_send_time_nanos,
+                    send_after_serialize_nanos,
+                    node_b_receive_time_nanos: receive_time_nanos,
+                    node_b_deserialize_done_nanos: deserialize_done_nanos,
+                });
+
+                Ok(())
+            }),
+        )
+        .await
+        .expect("Failed to subscribe to forward topic");
+
+    // Node A callback: receives echo and calculates detailed latencies
+    let middleware_a = middleware.clone();
+    let ref_time_a = reference_time;
+    let warmup = warmup_messages;
+    let received_count_clone = received_count.clone();
+    let forward_serialize_rx_clone = forward_serialize_rx.clone();
+
+    middleware
+        .subscribe_raw(
+            type_name,
+            &return_topic,
+            Box::new(move |payload: &[u8]| {
+                let receive_time_nanos = ref_time_a.elapsed().as_nanos() as u64;
+
+                // Deserialize and measure time
+                let serializer_a = middleware_a.get_serializer();
+                let (_metadata, data): (Metadata, JsonData) = serializer_a
+                    .deserialize_message(payload)
+                    .expect("Failed to deserialize return message");
+                let deserialize_done_nanos = ref_time_a.elapsed().as_nanos() as u64;
+
+                let json_data = data.get_data().unwrap();
+                let msg_id = json_data["msg_id"].as_u64().unwrap() as usize;
+                let original_send_time_nanos = json_data["original_send_time_nanos"].as_u64().unwrap();
+                let send_after_serialize_nanos = json_data["send_after_serialize_nanos"].as_u64().unwrap();
+                let node_b_receive_time_nanos = json_data["node_b_receive_time_nanos"].as_u64().unwrap();
+                let node_b_deserialize_done_nanos = json_data["node_b_deserialize_done_nanos"].as_u64().unwrap();
+                let node_b_serialize_time_ns = json_data["node_b_serialize_time_ns"].as_u64().unwrap();
+                let node_b_send_after_serialize_nanos = json_data["node_b_send_after_serialize_nanos"].as_u64().unwrap();
+
+                // Skip warmup messages
+                if msg_id >= warmup {
+                    // Forward leg breakdown
+                    let forward_transport_ms = (node_b_receive_time_nanos - send_after_serialize_nanos) as f64 / 1_000_000.0;
+                    let forward_deserialize_ms = (node_b_deserialize_done_nanos - node_b_receive_time_nanos) as f64 / 1_000_000.0;
+                    let forward_total_ms = (node_b_deserialize_done_nanos - original_send_time_nanos) as f64 / 1_000_000.0;
+
+                    // Return leg breakdown
+                    let return_serialize_ms = node_b_serialize_time_ns as f64 / 1_000_000.0;
+                    let return_transport_ms = (receive_time_nanos - node_b_send_after_serialize_nanos) as f64 / 1_000_000.0;
+                    let return_deserialize_ms = (deserialize_done_nanos - receive_time_nanos) as f64 / 1_000_000.0;
+                    let return_total_ms = (deserialize_done_nanos - node_b_deserialize_done_nanos) as f64 / 1_000_000.0;
+
+                    // Round-trip total
+                    let roundtrip_total_ms = (deserialize_done_nanos - original_send_time_nanos) as f64 / 1_000_000.0;
+
+                    // Get forward serialize time from channel (stored during send)
+                    let forward_serialize_ms = forward_serialize_rx_clone
+                        .lock()
+                        .ok()
+                        .and_then(|mut rx| rx.try_recv().ok())
+                        .unwrap_or(0.0);
+
+                    let _ = measurement_tx.try_send(DetailedLatencyMeasurement {
+                        forward_serialize_ms,
+                        forward_transport_ms,
+                        forward_deserialize_ms,
+                        forward_total_ms,
+                        return_serialize_ms,
+                        return_transport_ms,
+                        return_deserialize_ms,
+                        return_total_ms,
+                        roundtrip_total_ms,
+                    });
+                }
+
+                received_count_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+        )
+        .await
+        .expect("Failed to subscribe to return topic");
+
+    // Allow subscriptions to establish
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // Spawn echo publisher task (Node B's echo response with detailed timing)
+    let middleware_echo = middleware.clone();
+    let return_topic_echo = return_topic.clone();
+    let type_name_echo = type_name.to_string();
+    let ref_time_echo = reference_time;
+    let done_clone = done.clone();
+
+    let echo_task = tokio::spawn(async move {
+        let serializer_echo = middleware_echo.get_serializer();
+        while let Some(req) = echo_rx.recv().await {
+            if done_clone.load(Ordering::SeqCst) {
+                break;
+            }
+
+            // Measure serialization time
+            let serialize_start = ref_time_echo.elapsed().as_nanos() as u64;
+            let return_msg = json!({
+                "msg_id": req.msg_id,
+                "original_send_time_nanos": req.original_send_time_nanos,
+                "send_after_serialize_nanos": req.send_after_serialize_nanos,
+                "node_b_receive_time_nanos": req.node_b_receive_time_nanos,
+                "node_b_deserialize_done_nanos": req.node_b_deserialize_done_nanos,
+                "node_b_serialize_time_ns": 0u64, // Placeholder
+                "node_b_send_after_serialize_nanos": 0u64, // Placeholder
+            });
+            let return_data = JsonData::new(return_msg);
+            let metadata = Metadata::new(&return_topic_echo, &type_name_echo, None, None);
+            let _ = serializer_echo.serialize_message(&metadata, &return_data);
+            let serialize_done = ref_time_echo.elapsed().as_nanos() as u64;
+            let serialize_time_ns = serialize_done - serialize_start;
+
+            // Re-serialize with actual timing
+            let return_msg = json!({
+                "msg_id": req.msg_id,
+                "original_send_time_nanos": req.original_send_time_nanos,
+                "send_after_serialize_nanos": req.send_after_serialize_nanos,
+                "node_b_receive_time_nanos": req.node_b_receive_time_nanos,
+                "node_b_deserialize_done_nanos": req.node_b_deserialize_done_nanos,
+                "node_b_serialize_time_ns": serialize_time_ns,
+                "node_b_send_after_serialize_nanos": ref_time_echo.elapsed().as_nanos() as u64,
+            });
+            let return_data = JsonData::new(return_msg);
+            let payload = serializer_echo.serialize_message(&metadata, &return_data).unwrap();
+
+            let _ = middleware_echo
+                .publish_raw(&type_name_echo, &return_topic_echo, &payload)
+                .await;
+        }
+    });
+
+    // Generate payload
+    let payload_str = "x".repeat(payload_size);
+
+    // Send messages with detailed timing
+    let total_messages = num_messages + warmup_messages;
+    for i in 0..total_messages {
+        let send_time_nanos = reference_time.elapsed().as_nanos() as u64;
+
+        // First serialize to measure time
+        let message = json!({
+            "msg_id": i,
+            "send_time_nanos": send_time_nanos,
+            "send_after_serialize_nanos": 0u64, // Placeholder
+            "payload": payload_str,
+        });
+        let data = JsonData::new(message);
+        let metadata = Metadata::new(&forward_topic, type_name, None, None);
+
+        let serialize_start = reference_time.elapsed().as_nanos() as u64;
+        let _ = serializer.serialize_message(&metadata, &data);
+        let serialize_done = reference_time.elapsed().as_nanos() as u64;
+
+        // Re-serialize with actual timing
+        let message = json!({
+            "msg_id": i,
+            "send_time_nanos": send_time_nanos,
+            "send_after_serialize_nanos": serialize_done,
+            "payload": payload_str,
+        });
+        let data = JsonData::new(message);
+        let payload = serializer.serialize_message(&metadata, &data).unwrap();
+
+        // Store serialize time for warmup-filtered messages
+        if i >= warmup_messages {
+            let serialize_ms = (serialize_done - serialize_start) as f64 / 1_000_000.0;
+            let _ = forward_serialize_tx.try_send(serialize_ms);
+        }
+
+        middleware
+            .publish_raw(type_name, &forward_topic, &payload)
+            .await
+            .expect("Failed to publish forward message");
+
+        // Small delay between messages
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Wait for all messages with timeout
+    let timeout = Duration::from_secs(120);
+    let start = Instant::now();
+    while received_count.load(Ordering::SeqCst) < total_expected {
+        if start.elapsed() > timeout {
+            eprintln!(
+                "Warning: Timeout waiting for messages. Received {}/{}",
+                received_count.load(Ordering::SeqCst),
+                total_expected
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Signal done and cleanup
+    done.store(true, Ordering::SeqCst);
+
+    // Wait for echo task to finish
+    let _ = tokio::time::timeout(Duration::from_secs(2), echo_task).await;
+
+    // Collect measurements
+    let mut measurements = Vec::new();
+    while let Ok(m) = measurement_rx.try_recv() {
+        measurements.push(m);
+    }
+
+    measurements
+}
+
+#[tokio::main]
+async fn main() {
+    // Get transport name from command line args (default to "zenoh")
+    let args: Vec<String> = env::args().collect();
+    let transport_name = args.get(1).map(|s| s.as_str()).unwrap_or("zenoh");
+
+    println!("{} Publish-Subscribe Latency Benchmark (Rust)", transport_name.to_uppercase());
+    println!("{}", "=".repeat(60));
+
+    // Topic prefix using dash separator (works with both Zenoh and Kafka)
+    let topic_prefix = format!("benchmark-rust-{}", transport_name);
+
+    // Small messages benchmark (64 bytes)
+    println!("\nRunning small messages benchmark (64 bytes payload)...");
+    let measurements = run_benchmark(transport_name, 200, 10, 64, &format!("{}-small", topic_prefix)).await;
+    print_benchmark_results("Small Messages (64 bytes) Latency Benchmark", &measurements);
+
+    // Main benchmark (matches Python: 500 messages, 20 warmup, 64 bytes)
+    println!("\nRunning main benchmark (500 messages, 64 bytes payload)...");
+    let measurements = run_benchmark(transport_name, 500, 20, 64, &format!("{}-main", topic_prefix)).await;
+    print_benchmark_results("Main Benchmark (500 messages, 64 bytes)", &measurements);
+
+    // Large messages benchmark (500 KB)
+    println!("\nRunning large messages benchmark (500 KB payload)...");
+    let measurements = run_benchmark(transport_name, 100, 10, 500 * 1024, &format!("{}-large", topic_prefix)).await;
+    print_benchmark_results("Large Messages (500 KB) Latency Benchmark", &measurements);
+
+    // Detailed breakdown benchmark (500 KB)
+    println!("\nRunning detailed breakdown benchmark (500 KB payload)...");
+    let detailed_measurements = run_detailed_benchmark(transport_name, 100, 10, 500 * 1024, &format!("{}-detailed", topic_prefix)).await;
+    print_detailed_benchmark_results("Detailed Breakdown (500 KB) - Serialization vs Transport", &detailed_measurements);
+
+    // Varying load test
+    println!("\n\nVarying Load Test Results:");
+    println!("{}", "-".repeat(60));
+    for num_messages in [50, 200, 500] {
+        let measurements = run_benchmark(
+            transport_name,
+            num_messages,
+            10,
+            64,
+            &format!("{}-load-{}", topic_prefix, num_messages),
+        )
+        .await;
+        if !measurements.is_empty() {
+            let avg_roundtrip: f64 = measurements.iter().map(|m| m.roundtrip_latency_ms).sum::<f64>()
+                / measurements.len() as f64;
+            println!(
+                "{:>4} messages: avg round-trip = {:.3} ms",
+                num_messages,
+                avg_roundtrip
+            );
+        }
+    }
+    println!("{}", "-".repeat(60));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: These tests require the appropriate middleware feature to be enabled
+    // Run with: cargo test --example latency_benchmark --features zenoh
+    // or:       cargo test --example latency_benchmark --features kafka
+
+    #[tokio::test]
+    #[ignore] // Ignore by default as it requires middleware to be available
+    async fn test_latency_benchmark() {
+        // Try zenoh first, then kafka
+        let transport_name = if MiddlewareRegistry::new().get("zenoh").is_some() {
+            "zenoh"
+        } else if MiddlewareRegistry::new().get("kafka").is_some() {
+            "kafka"
+        } else {
+            panic!("No middleware available for testing");
+        };
+
+        let measurements = run_benchmark(transport_name, 50, 5, 64, "test-benchmark").await;
+
+        assert!(
+            !measurements.is_empty(),
+            "Should have collected measurements"
+        );
+
+        // Verify latencies are positive and reasonable
+        for m in &measurements {
+            assert!(
+                m.forward_latency_ms > 0.0,
+                "Forward latency should be positive"
+            );
+            assert!(
+                m.return_latency_ms > 0.0,
+                "Return latency should be positive"
+            );
+            assert!(
+                m.roundtrip_latency_ms > 0.0,
+                "Round-trip latency should be positive"
+            );
+            assert!(
+                m.roundtrip_latency_ms < 5000.0,
+                "Round-trip latency should be less than 5 seconds"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stats_calculation() {
+        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let stats = Stats::new(values);
+
+        assert!((stats.mean() - 3.0).abs() < 0.001);
+        assert!((stats.median() - 3.0).abs() < 0.001);
+        assert!((stats.min() - 1.0).abs() < 0.001);
+        assert!((stats.max() - 5.0).abs() < 0.001);
+    }
+}

--- a/aerosim-data/examples/latency_benchmark_minimal.rs
+++ b/aerosim-data/examples/latency_benchmark_minimal.rs
@@ -45,6 +45,16 @@ struct TimingMeasurement {
     roundtrip_ms: f64,
 }
 
+/// Shared timing data (avoids double serialization)
+#[derive(Debug, Clone, Default)]
+struct Timing {
+    t_start_a: u64,
+    t_ser_a: u64,
+    t_recv_b: u64,
+    t_deser_b: u64,
+    t_ser_b: u64,
+}
+
 #[tokio::main]
 async fn main() {
     // Parse transport from command line
@@ -78,6 +88,7 @@ async fn main() {
     let measurements: Arc<Mutex<Vec<TimingMeasurement>>> = Arc::new(Mutex::new(Vec::new()));
     let roundtrip_complete = Arc::new(Notify::new());
     let done = Arc::new(AtomicBool::new(false));
+    let timing = Arc::new(Mutex::new(Timing::default()));
 
     // Reference time for all measurements (using Instant for monotonic timing)
     let ref_time = Instant::now();
@@ -88,6 +99,8 @@ async fn main() {
     let echo_type_name = type_name.to_string();
     let echo_ref_time = ref_time;
     let echo_done = done.clone();
+    let echo_timing = timing.clone();
+    let echo_payload = payload_str.clone();
 
     middleware
         .subscribe_raw(
@@ -106,39 +119,30 @@ async fn main() {
                 } else {
                     echo_middleware.get_serializer()
                 };
-                let (_metadata, data): (Metadata, JsonData) = echo_ser
+                let (_metadata, _data): (Metadata, JsonData) = echo_ser
                     .deserialize_message(raw_bytes)
                     .expect("Failed to deserialize");
                 let t_deser_b = echo_ref_time.elapsed().as_nanos() as u64;
 
-                let json_data = data.get_data().unwrap();
-                let t_start_a = json_data["t_start_a"].as_u64().unwrap_or(0);
-                let t_ser_a = json_data["t_ser_a"].as_u64().unwrap_or(0);
+                // Store timing in shared struct
+                if let Ok(mut t) = echo_timing.lock() {
+                    t.t_recv_b = t_recv_b;
+                    t.t_deser_b = t_deser_b;
+                }
 
-                // Create echo with timing data (first pass to measure serialize time)
+                // Create and serialize echo (payload only, timestamps in shared struct)
                 let echo_data = JsonData::new(json!({
-                    "t_start_a": t_start_a,
-                    "t_ser_a": t_ser_a,
-                    "t_recv_b": t_recv_b,
-                    "t_deser_b": t_deser_b,
+                    "payload": echo_payload.clone(),
                 }));
-
                 let metadata = Metadata::new(&echo_return_topic, &echo_type_name, None, None);
-                let _ = echo_ser.serialize_message(&metadata, &echo_data);
-                let t_ser_b = echo_ref_time.elapsed().as_nanos() as u64;
-
-                // Re-serialize with t_ser_b included
-                let echo_data_final = JsonData::new(json!({
-                    "t_start_a": t_start_a,
-                    "t_ser_a": t_ser_a,
-                    "t_recv_b": t_recv_b,
-                    "t_deser_b": t_deser_b,
-                    "t_ser_b": t_ser_b,
-                }));
-
                 let echo_bytes = echo_ser
-                    .serialize_message(&metadata, &echo_data_final)
+                    .serialize_message(&metadata, &echo_data)
                     .expect("Serialize failed");
+
+                // Store serialize time in shared struct
+                if let Ok(mut t) = echo_timing.lock() {
+                    t.t_ser_b = echo_ref_time.elapsed().as_nanos() as u64;
+                }
 
                 let mw = echo_middleware.clone();
                 let topic = echo_return_topic.clone();
@@ -158,6 +162,7 @@ async fn main() {
     let measure_measurements = measurements.clone();
     let measure_notify = roundtrip_complete.clone();
     let measure_ref_time = ref_time;
+    let measure_timing = timing.clone();
 
     middleware
         .subscribe_raw(
@@ -172,33 +177,26 @@ async fn main() {
                 } else {
                     measure_middleware.get_serializer()
                 };
-                let (_metadata, data): (Metadata, JsonData) = measure_ser
+                let (_metadata, _data): (Metadata, JsonData) = measure_ser
                     .deserialize_message(raw_bytes)
                     .expect("Failed to deserialize");
                 let t_deser_a = measure_ref_time.elapsed().as_nanos() as u64;
 
-                let json_data = data.get_data().unwrap();
+                // Calculate timing breakdown using shared struct (convert nanos to ms)
+                if let Ok(t) = measure_timing.lock() {
+                    let measurement = TimingMeasurement {
+                        serialize_a_ms: (t.t_ser_a - t.t_start_a) as f64 / 1_000_000.0,
+                        transport_ab_ms: (t.t_recv_b - t.t_ser_a) as f64 / 1_000_000.0,
+                        deserialize_b_ms: (t.t_deser_b - t.t_recv_b) as f64 / 1_000_000.0,
+                        serialize_b_ms: (t.t_ser_b - t.t_deser_b) as f64 / 1_000_000.0,
+                        transport_ba_ms: (t_recv_a - t.t_ser_b) as f64 / 1_000_000.0,
+                        deserialize_a_ms: (t_deser_a - t_recv_a) as f64 / 1_000_000.0,
+                        roundtrip_ms: (t_deser_a - t.t_start_a) as f64 / 1_000_000.0,
+                    };
 
-                // Extract all timestamps (in nanoseconds)
-                let t_start_a = json_data["t_start_a"].as_u64().unwrap_or(0);
-                let t_ser_a = json_data["t_ser_a"].as_u64().unwrap_or(0);
-                let t_recv_b = json_data["t_recv_b"].as_u64().unwrap_or(0);
-                let t_deser_b = json_data["t_deser_b"].as_u64().unwrap_or(0);
-                let t_ser_b = json_data["t_ser_b"].as_u64().unwrap_or(0);
-
-                // Calculate timing breakdown (convert nanos to ms)
-                let measurement = TimingMeasurement {
-                    serialize_a_ms: (t_ser_a - t_start_a) as f64 / 1_000_000.0,
-                    transport_ab_ms: (t_recv_b - t_ser_a) as f64 / 1_000_000.0,
-                    deserialize_b_ms: (t_deser_b - t_recv_b) as f64 / 1_000_000.0,
-                    serialize_b_ms: (t_ser_b - t_deser_b) as f64 / 1_000_000.0,
-                    transport_ba_ms: (t_recv_a - t_ser_b) as f64 / 1_000_000.0,
-                    deserialize_a_ms: (t_deser_a - t_recv_a) as f64 / 1_000_000.0,
-                    roundtrip_ms: (t_deser_a - t_start_a) as f64 / 1_000_000.0,
-                };
-
-                if let Ok(mut m) = measure_measurements.lock() {
-                    m.push(measurement);
+                    if let Ok(mut m) = measure_measurements.lock() {
+                        m.push(measurement);
+                    }
                 }
                 measure_notify.notify_one();
 
@@ -223,16 +221,19 @@ async fn main() {
 
     // --- Warmup loop (not measured) ---
     {
-        let t_start = ref_time.elapsed().as_nanos() as u64;
+        if let Ok(mut t) = timing.lock() {
+            t.t_start_a = ref_time.elapsed().as_nanos() as u64;
+        }
         let warmup_msg = JsonData::new(json!({
-            "t_start_a": t_start,
-            "t_ser_a": t_start,
             "payload": payload_str.clone(),
         }));
         let metadata = Metadata::new(&forward_topic, type_name, None, None);
         let raw_bytes = serializer
             .serialize_message(&metadata, &warmup_msg)
             .expect("Serialize failed");
+        if let Ok(mut t) = timing.lock() {
+            t.t_ser_a = ref_time.elapsed().as_nanos() as u64;
+        }
         middleware
             .publish_raw(type_name, &forward_topic, &raw_bytes)
             .await
@@ -249,27 +250,26 @@ async fn main() {
 
     // --- Measured loops ---
     for i in 0..NUM_MESSAGES {
-        // Create message with timestamp and payload
-        let t_start_a = ref_time.elapsed().as_nanos() as u64;
+        // Store start time in shared struct
+        if let Ok(mut t) = timing.lock() {
+            t.t_start_a = ref_time.elapsed().as_nanos() as u64;
+        }
+
+        // Create message with payload (timestamps stored in shared struct)
         let message = JsonData::new(json!({
-            "t_start_a": t_start_a,
             "payload": payload_str.clone(),
         }));
 
-        // Serialize (first pass to measure time)
+        // Serialize
         let metadata = Metadata::new(&forward_topic, type_name, None, None);
-        let _ = serializer.serialize_message(&metadata, &message);
-        let t_ser_a = ref_time.elapsed().as_nanos() as u64;
-
-        // Re-serialize with t_ser_a included
-        let message_final = JsonData::new(json!({
-            "t_start_a": t_start_a,
-            "t_ser_a": t_ser_a,
-            "payload": payload_str.clone(),
-        }));
         let raw_bytes = serializer
-            .serialize_message(&metadata, &message_final)
+            .serialize_message(&metadata, &message)
             .expect("Serialize failed");
+
+        // Store serialize time in shared struct
+        if let Ok(mut t) = timing.lock() {
+            t.t_ser_a = ref_time.elapsed().as_nanos() as u64;
+        }
 
         // Publish
         middleware

--- a/aerosim-data/examples/latency_benchmark_minimal.rs
+++ b/aerosim-data/examples/latency_benchmark_minimal.rs
@@ -1,0 +1,345 @@
+//! Minimal latency benchmark for middleware pub/sub round-trip timing.
+//!
+//! A simple, readable benchmark that measures round-trip latency between two nodes
+//! with detailed breakdown of serialization, transport, and deserialization times.
+//!
+//! Uses the raw publish/subscribe API with explicit serialization for clarity.
+//!
+//! Run with:
+//!   cargo run --example latency_benchmark_minimal -- zenoh
+//!   cargo run --example latency_benchmark_minimal -- kafka
+//!
+//! Configure via constants below: PAYLOAD_SIZE_BYTES, NUM_MESSAGES, USE_BINCODE
+
+use std::env;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+use tokio::sync::Notify;
+
+use aerosim_data::middleware::{
+    BincodeSerializer, Metadata, Middleware, MiddlewareRaw, MiddlewareRegistry, Serializer,
+    SerializerEnum,
+};
+use aerosim_data::types::JsonData;
+
+// =============================================================================
+// CONFIGURATION - Modify these to change benchmark parameters
+// =============================================================================
+const PAYLOAD_SIZE_BYTES: usize = 1024; // Size of test payload (e.g., 64, 1024, 512000)
+const NUM_MESSAGES: usize = 1;          // Number of round-trips to measure
+const USE_BINCODE: bool = false;        // true for bincode, false for JSON serialization
+// =============================================================================
+
+/// Detailed timing measurement for one round-trip
+#[derive(Debug, Clone, Default)]
+struct TimingMeasurement {
+    serialize_a_ms: f64,
+    transport_ab_ms: f64,
+    deserialize_b_ms: f64,
+    serialize_b_ms: f64,
+    transport_ba_ms: f64,
+    deserialize_a_ms: f64,
+    roundtrip_ms: f64,
+}
+
+#[tokio::main]
+async fn main() {
+    // Parse transport from command line
+    let args: Vec<String> = env::args().collect();
+    let transport_name = args.get(1).map(|s| s.as_str()).unwrap_or("zenoh");
+
+    // Create middleware and serializer
+    let registry = MiddlewareRegistry::new();
+    let middleware = registry
+        .get(transport_name)
+        .unwrap_or_else(|| panic!("{} middleware not available", transport_name));
+    let serializer = if USE_BINCODE {
+        SerializerEnum::from(BincodeSerializer)
+    } else {
+        middleware.get_serializer()
+    };
+
+    // Create unique topic names using timestamp
+    let unique_id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+    let forward_topic = format!("bench-{}-fwd", unique_id);
+    let return_topic = format!("bench-{}-ret", unique_id);
+    let type_name = "aerosim::types::JsonData";
+
+    // Create test payload
+    let payload_str: String = "x".repeat(PAYLOAD_SIZE_BYTES);
+
+    // Shared state for round-trip synchronization
+    let measurements: Arc<Mutex<Vec<TimingMeasurement>>> = Arc::new(Mutex::new(Vec::new()));
+    let roundtrip_complete = Arc::new(Notify::new());
+    let done = Arc::new(AtomicBool::new(false));
+
+    // Reference time for all measurements (using Instant for monotonic timing)
+    let ref_time = Instant::now();
+
+    // --- Node B: Echo service ---
+    let echo_middleware = middleware.clone();
+    let echo_return_topic = return_topic.clone();
+    let echo_type_name = type_name.to_string();
+    let echo_ref_time = ref_time;
+    let echo_done = done.clone();
+
+    middleware
+        .subscribe_raw(
+            type_name,
+            &forward_topic,
+            Box::new(move |raw_bytes: &[u8]| {
+                if echo_done.load(Ordering::SeqCst) {
+                    return Ok(());
+                }
+
+                let t_recv_b = echo_ref_time.elapsed().as_nanos() as u64;
+
+                // Deserialize incoming message
+                let echo_ser = if USE_BINCODE {
+                    SerializerEnum::from(BincodeSerializer)
+                } else {
+                    echo_middleware.get_serializer()
+                };
+                let (_metadata, data): (Metadata, JsonData) = echo_ser
+                    .deserialize_message(raw_bytes)
+                    .expect("Failed to deserialize");
+                let t_deser_b = echo_ref_time.elapsed().as_nanos() as u64;
+
+                let json_data = data.get_data().unwrap();
+                let t_start_a = json_data["t_start_a"].as_u64().unwrap_or(0);
+                let t_ser_a = json_data["t_ser_a"].as_u64().unwrap_or(0);
+
+                // Create echo with timing data (first pass to measure serialize time)
+                let echo_data = JsonData::new(json!({
+                    "t_start_a": t_start_a,
+                    "t_ser_a": t_ser_a,
+                    "t_recv_b": t_recv_b,
+                    "t_deser_b": t_deser_b,
+                }));
+
+                let metadata = Metadata::new(&echo_return_topic, &echo_type_name, None, None);
+                let _ = echo_ser.serialize_message(&metadata, &echo_data);
+                let t_ser_b = echo_ref_time.elapsed().as_nanos() as u64;
+
+                // Re-serialize with t_ser_b included
+                let echo_data_final = JsonData::new(json!({
+                    "t_start_a": t_start_a,
+                    "t_ser_a": t_ser_a,
+                    "t_recv_b": t_recv_b,
+                    "t_deser_b": t_deser_b,
+                    "t_ser_b": t_ser_b,
+                }));
+
+                let echo_bytes = echo_ser
+                    .serialize_message(&metadata, &echo_data_final)
+                    .expect("Serialize failed");
+
+                let mw = echo_middleware.clone();
+                let topic = echo_return_topic.clone();
+                let type_n = echo_type_name.clone();
+                tokio::spawn(async move {
+                    let _ = mw.publish_raw(&type_n, &topic, &echo_bytes).await;
+                });
+
+                Ok(())
+            }),
+        )
+        .await
+        .expect("Failed to subscribe to forward topic");
+
+    // --- Node A: Latency measurer ---
+    let measure_middleware = middleware.clone();
+    let measure_measurements = measurements.clone();
+    let measure_notify = roundtrip_complete.clone();
+    let measure_ref_time = ref_time;
+
+    middleware
+        .subscribe_raw(
+            type_name,
+            &return_topic,
+            Box::new(move |raw_bytes: &[u8]| {
+                let t_recv_a = measure_ref_time.elapsed().as_nanos() as u64;
+
+                // Deserialize echo message
+                let measure_ser = if USE_BINCODE {
+                    SerializerEnum::from(BincodeSerializer)
+                } else {
+                    measure_middleware.get_serializer()
+                };
+                let (_metadata, data): (Metadata, JsonData) = measure_ser
+                    .deserialize_message(raw_bytes)
+                    .expect("Failed to deserialize");
+                let t_deser_a = measure_ref_time.elapsed().as_nanos() as u64;
+
+                let json_data = data.get_data().unwrap();
+
+                // Extract all timestamps (in nanoseconds)
+                let t_start_a = json_data["t_start_a"].as_u64().unwrap_or(0);
+                let t_ser_a = json_data["t_ser_a"].as_u64().unwrap_or(0);
+                let t_recv_b = json_data["t_recv_b"].as_u64().unwrap_or(0);
+                let t_deser_b = json_data["t_deser_b"].as_u64().unwrap_or(0);
+                let t_ser_b = json_data["t_ser_b"].as_u64().unwrap_or(0);
+
+                // Calculate timing breakdown (convert nanos to ms)
+                let measurement = TimingMeasurement {
+                    serialize_a_ms: (t_ser_a - t_start_a) as f64 / 1_000_000.0,
+                    transport_ab_ms: (t_recv_b - t_ser_a) as f64 / 1_000_000.0,
+                    deserialize_b_ms: (t_deser_b - t_recv_b) as f64 / 1_000_000.0,
+                    serialize_b_ms: (t_ser_b - t_deser_b) as f64 / 1_000_000.0,
+                    transport_ba_ms: (t_recv_a - t_ser_b) as f64 / 1_000_000.0,
+                    deserialize_a_ms: (t_deser_a - t_recv_a) as f64 / 1_000_000.0,
+                    roundtrip_ms: (t_deser_a - t_start_a) as f64 / 1_000_000.0,
+                };
+
+                if let Ok(mut m) = measure_measurements.lock() {
+                    m.push(measurement);
+                }
+                measure_notify.notify_one();
+
+                Ok(())
+            }),
+        )
+        .await
+        .expect("Failed to subscribe to return topic");
+
+    // Wait for subscriptions to be ready
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // --- Run the benchmark ---
+    println!("\n{}", "=".repeat(60));
+    let serialization_type = if USE_BINCODE { "Bincode" } else { "JSON" };
+    println!("{} Minimal Latency Benchmark", transport_name.to_uppercase());
+    println!(
+        "Payload: {} bytes | Serialization: {}",
+        PAYLOAD_SIZE_BYTES, serialization_type
+    );
+    println!("{}", "=".repeat(60));
+
+    // --- Warmup loop (not measured) ---
+    {
+        let t_start = ref_time.elapsed().as_nanos() as u64;
+        let warmup_msg = JsonData::new(json!({
+            "t_start_a": t_start,
+            "t_ser_a": t_start,
+            "payload": payload_str.clone(),
+        }));
+        let metadata = Metadata::new(&forward_topic, type_name, None, None);
+        let raw_bytes = serializer
+            .serialize_message(&metadata, &warmup_msg)
+            .expect("Serialize failed");
+        middleware
+            .publish_raw(type_name, &forward_topic, &raw_bytes)
+            .await
+            .expect("Publish failed");
+
+        // Wait for warmup to complete
+        tokio::time::timeout(Duration::from_secs(30), roundtrip_complete.notified())
+            .await
+            .ok();
+        if let Ok(mut m) = measurements.lock() {
+            m.clear();
+        }
+    }
+
+    // --- Measured loops ---
+    for i in 0..NUM_MESSAGES {
+        // Create message with timestamp and payload
+        let t_start_a = ref_time.elapsed().as_nanos() as u64;
+        let message = JsonData::new(json!({
+            "t_start_a": t_start_a,
+            "payload": payload_str.clone(),
+        }));
+
+        // Serialize (first pass to measure time)
+        let metadata = Metadata::new(&forward_topic, type_name, None, None);
+        let _ = serializer.serialize_message(&metadata, &message);
+        let t_ser_a = ref_time.elapsed().as_nanos() as u64;
+
+        // Re-serialize with t_ser_a included
+        let message_final = JsonData::new(json!({
+            "t_start_a": t_start_a,
+            "t_ser_a": t_ser_a,
+            "payload": payload_str.clone(),
+        }));
+        let raw_bytes = serializer
+            .serialize_message(&metadata, &message_final)
+            .expect("Serialize failed");
+
+        // Publish
+        middleware
+            .publish_raw(type_name, &forward_topic, &raw_bytes)
+            .await
+            .expect("Publish failed");
+
+        // Wait for this message to complete round-trip before sending next
+        if tokio::time::timeout(Duration::from_secs(30), roundtrip_complete.notified())
+            .await
+            .is_err()
+        {
+            println!("Timeout waiting for message {}", i);
+            break;
+        }
+    }
+
+    // Signal done
+    done.store(true, Ordering::SeqCst);
+
+    // --- Print results ---
+    let results = measurements.lock().unwrap();
+    if !results.is_empty() {
+        let avg_label = if results.len() > 1 { " (ave)" } else { "" };
+        let n = results.len() as f64;
+
+        let avg = |f: fn(&TimingMeasurement) -> f64| -> f64 {
+            results.iter().map(f).sum::<f64>() / n
+        };
+
+        println!("\nDetailed Latency Breakdown ({} samples):", results.len());
+        println!("\nForward (A -> B):");
+        println!(
+            "  Serialize A:   {:.3} ms{}",
+            avg(|m| m.serialize_a_ms),
+            avg_label
+        );
+        println!(
+            "  Transport A→B: {:.3} ms{}",
+            avg(|m| m.transport_ab_ms),
+            avg_label
+        );
+        println!(
+            "  Deserialize B: {:.3} ms{}",
+            avg(|m| m.deserialize_b_ms),
+            avg_label
+        );
+        println!("\nReturn (B -> A):");
+        println!(
+            "  Serialize B:   {:.3} ms{}",
+            avg(|m| m.serialize_b_ms),
+            avg_label
+        );
+        println!(
+            "  Transport B→A: {:.3} ms{}",
+            avg(|m| m.transport_ba_ms),
+            avg_label
+        );
+        println!(
+            "  Deserialize A: {:.3} ms{}",
+            avg(|m| m.deserialize_a_ms),
+            avg_label
+        );
+        println!(
+            "\nTotal Round-Trip: {:.3} ms{}",
+            avg(|m| m.roundtrip_ms),
+            avg_label
+        );
+        println!("{}\n", "=".repeat(60));
+    } else {
+        println!("No latency measurements received!");
+    }
+}

--- a/aerosim-data/tests/test_latency_benchmark.py
+++ b/aerosim-data/tests/test_latency_benchmark.py
@@ -1,0 +1,966 @@
+"""
+Performance benchmark tests for middleware publish-subscribe latency.
+
+This module tests round-trip latency between two nodes using various middleware transports,
+measuring message latency in both directions. Supports Zenoh and Kafka transports.
+
+Run with:
+    pytest aerosim-data/tests/test_latency_benchmark.py -v              # All transports
+    pytest aerosim-data/tests/test_latency_benchmark.py -v -k "zenoh"   # Zenoh only
+    pytest aerosim-data/tests/test_latency_benchmark.py -v -k "kafka"   # Kafka only
+    pytest aerosim-data/tests/test_latency_benchmark.py -v -s           # Show benchmark output
+"""
+import pytest
+import time
+import threading
+import statistics
+import uuid
+from dataclasses import dataclass
+from typing import List
+
+from aerosim_data import middleware as aerosim_middleware
+from aerosim_data import types as aerosim_types
+
+
+# Transport configuration
+# Note: Using "-" as separator for all transports since it's valid for both Zenoh and Kafka.
+# Kafka topic names don't support "/" characters.
+TRANSPORT_CONFIGS = {
+    "zenoh": {
+        "serializer_class": "ZenohSerializer",
+    },
+    "kafka": {
+        "serializer_class": "KafkaSerializer",
+    },
+}
+
+# Topic separator that works on all transports (Kafka doesn't support "/")
+TOPIC_SEPARATOR = "-"
+
+
+def get_serializer(transport_name: str):
+    """Get the appropriate JSON serializer for the transport."""
+    config = TRANSPORT_CONFIGS.get(transport_name, {})
+    serializer_class = config.get("serializer_class", "ZenohSerializer")
+    return getattr(aerosim_middleware, serializer_class)()
+
+
+@dataclass
+class LatencyResult:
+    """Stores latency measurement results."""
+    forward_latencies_ms: List[float]
+    return_latencies_ms: List[float]
+    roundtrip_latencies_ms: List[float]
+
+    def print_summary(self, title: str = "Publish-Subscribe Latency Benchmark Results"):
+        """Print a summary of the latency measurements."""
+        print("\n" + "=" * 60)
+        print(title)
+        print("=" * 60)
+
+        if self.forward_latencies_ms:
+            print("\nForward Latency (Node A -> Node B):")
+            print(f"  Samples: {len(self.forward_latencies_ms)}")
+            print(f"  Average: {statistics.mean(self.forward_latencies_ms):.3f} ms")
+            print(f"  Median:  {statistics.median(self.forward_latencies_ms):.3f} ms")
+            print(f"  Min:     {min(self.forward_latencies_ms):.3f} ms")
+            print(f"  Max:     {max(self.forward_latencies_ms):.3f} ms")
+            if len(self.forward_latencies_ms) > 1:
+                print(f"  Std Dev: {statistics.stdev(self.forward_latencies_ms):.3f} ms")
+
+        if self.return_latencies_ms:
+            print("\nReturn Latency (Node B -> Node A):")
+            print(f"  Samples: {len(self.return_latencies_ms)}")
+            print(f"  Average: {statistics.mean(self.return_latencies_ms):.3f} ms")
+            print(f"  Median:  {statistics.median(self.return_latencies_ms):.3f} ms")
+            print(f"  Min:     {min(self.return_latencies_ms):.3f} ms")
+            print(f"  Max:     {max(self.return_latencies_ms):.3f} ms")
+            if len(self.return_latencies_ms) > 1:
+                print(f"  Std Dev: {statistics.stdev(self.return_latencies_ms):.3f} ms")
+
+        if self.roundtrip_latencies_ms:
+            print("\nRound-Trip Latency (Node A -> Node B -> Node A):")
+            print(f"  Samples: {len(self.roundtrip_latencies_ms)}")
+            print(f"  Average: {statistics.mean(self.roundtrip_latencies_ms):.3f} ms")
+            print(f"  Median:  {statistics.median(self.roundtrip_latencies_ms):.3f} ms")
+            print(f"  Min:     {min(self.roundtrip_latencies_ms):.3f} ms")
+            print(f"  Max:     {max(self.roundtrip_latencies_ms):.3f} ms")
+            if len(self.roundtrip_latencies_ms) > 1:
+                print(f"  Std Dev: {statistics.stdev(self.roundtrip_latencies_ms):.3f} ms")
+
+        print("\n" + "=" * 60)
+
+
+@dataclass
+class DetailedLatencyResult:
+    """Stores detailed latency measurement results with serialization/transport breakdown."""
+    # Total latencies
+    forward_latencies_ms: List[float]
+    return_latencies_ms: List[float]
+    roundtrip_latencies_ms: List[float]
+
+    # Forward leg breakdown (Node A -> Node B)
+    forward_serialize_ms: List[float]  # Node A serialization time
+    forward_transport_ms: List[float]  # Network transport time
+    forward_deserialize_ms: List[float]  # Node B deserialization time
+
+    # Return leg breakdown (Node B -> Node A)
+    return_serialize_ms: List[float]  # Node B serialization time
+    return_transport_ms: List[float]  # Network transport time
+    return_deserialize_ms: List[float]  # Node A deserialization time
+
+    def _print_stats(self, name: str, values: List[float], indent: str = "  "):
+        """Print statistics for a list of values."""
+        if not values:
+            return
+        print(f"{indent}{name}:")
+        print(f"{indent}  Average: {statistics.mean(values):.3f} ms")
+        if len(values) > 1:
+            print(f"{indent}  Median:  {statistics.median(values):.3f} ms")
+            print(f"{indent}  Min:     {min(values):.3f} ms")
+            print(f"{indent}  Max:     {max(values):.3f} ms")
+
+    def print_summary(self, title: str = "Detailed Latency Benchmark Results"):
+        """Print a summary of the detailed latency measurements."""
+        print("\n" + "=" * 70)
+        print(title)
+        print("=" * 70)
+        print(f"Samples: {len(self.roundtrip_latencies_ms)}")
+
+        # Forward leg
+        if self.forward_latencies_ms:
+            print(f"\nForward Leg (Node A -> Node B): {statistics.mean(self.forward_latencies_ms):.3f} ms avg")
+            self._print_stats("Serialize (Node A)", self.forward_serialize_ms)
+            self._print_stats("Transport", self.forward_transport_ms)
+            self._print_stats("Deserialize (Node B)", self.forward_deserialize_ms)
+
+        # Return leg
+        if self.return_latencies_ms:
+            print(f"\nReturn Leg (Node B -> Node A): {statistics.mean(self.return_latencies_ms):.3f} ms avg")
+            self._print_stats("Serialize (Node B)", self.return_serialize_ms)
+            self._print_stats("Transport", self.return_transport_ms)
+            self._print_stats("Deserialize (Node A)", self.return_deserialize_ms)
+
+        # Round-trip summary
+        if self.roundtrip_latencies_ms:
+            print(f"\nRound-Trip Total: {statistics.mean(self.roundtrip_latencies_ms):.3f} ms avg")
+
+            # Calculate aggregate averages
+            total_serialize = (
+                statistics.mean(self.forward_serialize_ms) +
+                statistics.mean(self.return_serialize_ms)
+            ) if self.forward_serialize_ms and self.return_serialize_ms else 0
+
+            total_transport = (
+                statistics.mean(self.forward_transport_ms) +
+                statistics.mean(self.return_transport_ms)
+            ) if self.forward_transport_ms and self.return_transport_ms else 0
+
+            total_deserialize = (
+                statistics.mean(self.forward_deserialize_ms) +
+                statistics.mean(self.return_deserialize_ms)
+            ) if self.forward_deserialize_ms and self.return_deserialize_ms else 0
+
+            total_time = total_serialize + total_transport + total_deserialize
+            if total_time > 0:
+                print("\n  Breakdown (averages):")
+                print(f"    Total Serialize:   {total_serialize:.3f} ms ({100*total_serialize/total_time:.1f}%)")
+                print(f"    Total Transport:   {total_transport:.3f} ms ({100*total_transport/total_time:.1f}%)")
+                print(f"    Total Deserialize: {total_deserialize:.3f} ms ({100*total_deserialize/total_time:.1f}%)")
+
+        print("\n" + "=" * 70)
+
+
+class LatencyBenchmark:
+    """
+    Benchmarks pub-sub latency using a round-trip message pattern.
+
+    Node A publishes messages with timestamps to a forward topic.
+    Node B receives them, records forward latency, and echoes back to a return topic.
+    Node A receives the echo and records return and round-trip latency.
+    """
+
+    def __init__(self, transport, transport_name: str = "zenoh", num_messages: int = 100,
+                 warmup_messages: int = 10, topic_prefix: str = None, payload_size: int = 64):
+        self.transport = transport
+        self.transport_name = transport_name
+        self.num_messages = num_messages
+        self.warmup_messages = warmup_messages
+        self.payload_size = payload_size
+
+        # Use transport-appropriate topic separator
+        sep = TOPIC_SEPARATOR
+        self.topic_prefix = topic_prefix or f"benchmark{sep}{uuid.uuid4().hex[:8]}"
+        self.forward_topic = f"{self.topic_prefix}{sep}forward"
+        self.return_topic = f"{self.topic_prefix}{sep}return"
+
+        # Latency storage
+        self.forward_latencies_ms: List[float] = []
+        self.return_latencies_ms: List[float] = []
+        self.roundtrip_latencies_ms: List[float] = []
+
+        # Track message timing
+        self.send_times: dict = {}
+        self.node_b_receive_times: dict = {}
+
+        # Synchronization
+        self.messages_received = 0
+        self.lock = threading.Lock()
+        self.all_received = threading.Event()
+
+    def _node_b_callback(self, data: dict, metadata):
+        """
+        Node B's callback: receives forward message, records timing, echoes back.
+        """
+        receive_time = time.perf_counter()
+        msg_id = data.get("msg_id")
+        send_time = data.get("send_time")
+
+        if msg_id is not None and send_time is not None:
+            # Record Node B receive time for forward latency calculation
+            with self.lock:
+                self.node_b_receive_times[msg_id] = receive_time
+
+            # Echo the message back with Node B's timestamp added
+            echo_data = {
+                "msg_id": msg_id,
+                "original_send_time": send_time,
+                "node_b_receive_time": receive_time,
+                "node_b_send_time": time.perf_counter()
+            }
+            self.transport.publish(self.return_topic, echo_data)
+
+    def _node_a_callback(self, data: dict, metadata):
+        """
+        Node A's callback: receives echo, calculates latencies.
+        """
+        receive_time = time.perf_counter()
+        msg_id = data.get("msg_id")
+        original_send_time = data.get("original_send_time")
+        node_b_receive_time = data.get("node_b_receive_time")
+        node_b_send_time = data.get("node_b_send_time")
+
+        if all(v is not None for v in [msg_id, original_send_time, node_b_receive_time, node_b_send_time]):
+            # Skip warmup messages
+            if msg_id >= self.warmup_messages:
+                # Forward latency: original send -> Node B receive
+                forward_latency = (node_b_receive_time - original_send_time) * 1000
+
+                # Return latency: Node B send -> Node A receive
+                return_latency = (receive_time - node_b_send_time) * 1000
+
+                # Round-trip latency: original send -> Node A receive
+                roundtrip_latency = (receive_time - original_send_time) * 1000
+
+                with self.lock:
+                    self.forward_latencies_ms.append(forward_latency)
+                    self.return_latencies_ms.append(return_latency)
+                    self.roundtrip_latencies_ms.append(roundtrip_latency)
+
+            with self.lock:
+                self.messages_received += 1
+                if self.messages_received >= self.num_messages + self.warmup_messages:
+                    self.all_received.set()
+
+    def run(self, timeout: float = 60.0) -> LatencyResult:
+        """
+        Run the latency benchmark.
+
+        Args:
+            timeout: Maximum time to wait for all messages (seconds).
+
+        Returns:
+            LatencyResult with measured latencies.
+        """
+        # Set up subscriptions with unique topics
+        self.transport.subscribe(aerosim_types.JsonData, self.forward_topic, self._node_b_callback)
+        self.transport.subscribe(aerosim_types.JsonData, self.return_topic, self._node_a_callback)
+
+        # Allow subscriptions to establish
+        time.sleep(1.0)
+
+        # Send messages (warmup + actual)
+        total_messages = self.num_messages + self.warmup_messages
+        for i in range(total_messages):
+            send_time = time.perf_counter()
+            self.send_times[i] = send_time
+
+            message = {
+                "msg_id": i,
+                "send_time": send_time,
+                "payload": "x" * self.payload_size
+            }
+            self.transport.publish(self.forward_topic, message)
+
+            # Small delay between messages to avoid overwhelming the system
+            time.sleep(0.02)
+
+        # Wait for all messages to complete round-trip
+        if not self.all_received.wait(timeout=timeout):
+            print(f"Warning: Timeout waiting for messages. Received {self.messages_received}/{total_messages}")
+
+        return LatencyResult(
+            forward_latencies_ms=self.forward_latencies_ms.copy(),
+            return_latencies_ms=self.return_latencies_ms.copy(),
+            roundtrip_latencies_ms=self.roundtrip_latencies_ms.copy()
+        )
+
+
+class LatencyBenchmarkBincode:
+    """
+    Benchmarks pub-sub latency using bincode serialization instead of JSON.
+
+    This uses raw pub/sub with BincodeSerializer to compare binary vs JSON serialization.
+    """
+
+    def __init__(self, transport, transport_name: str = "zenoh", num_messages: int = 100,
+                 warmup_messages: int = 10, topic_prefix: str = None, payload_size: int = 64):
+        self.transport = transport
+        self.transport_name = transport_name
+        self.serializer = aerosim_middleware.BincodeSerializer()
+        self.num_messages = num_messages
+        self.warmup_messages = warmup_messages
+        self.payload_size = payload_size
+
+        # Use transport-appropriate topic separator
+        sep = TOPIC_SEPARATOR
+        self.topic_prefix = topic_prefix or f"benchmark{sep}bincode{sep}{uuid.uuid4().hex[:8]}"
+        self.forward_topic = f"{self.topic_prefix}{sep}forward"
+        self.return_topic = f"{self.topic_prefix}{sep}return"
+
+        # Latency storage
+        self.forward_latencies_ms: List[float] = []
+        self.return_latencies_ms: List[float] = []
+        self.roundtrip_latencies_ms: List[float] = []
+
+        # Track message timing
+        self.send_times: dict = {}
+        self.node_b_receive_times: dict = {}
+
+        # Synchronization
+        self.messages_received = 0
+        self.lock = threading.Lock()
+        self.all_received = threading.Event()
+
+    def _node_b_callback(self, payload: bytes):
+        """
+        Node B's callback: receives forward message, records timing, echoes back using bincode.
+        """
+        receive_time = time.perf_counter()
+
+        # Deserialize using bincode
+        _metadata, data = self.serializer.deserialize_message(aerosim_types.JsonData, payload)
+        json_data = data.get_data()
+        msg_id = json_data.get("msg_id")
+        send_time = json_data.get("send_time")
+
+        if msg_id is not None and send_time is not None:
+            with self.lock:
+                self.node_b_receive_times[msg_id] = receive_time
+
+            # Echo back with bincode serialization
+            echo_data = aerosim_types.JsonData({
+                "msg_id": msg_id,
+                "original_send_time": send_time,
+                "node_b_receive_time": receive_time,
+                "node_b_send_time": time.perf_counter()
+            })
+            metadata = aerosim_middleware.Metadata(
+                self.return_topic, "aerosim::types::JsonData"
+            )
+            echo_payload = self.serializer.serialize_message(metadata, echo_data)
+            self.transport.publish_raw("aerosim::types::JsonData", self.return_topic, echo_payload)
+
+    def _node_a_callback(self, payload: bytes):
+        """
+        Node A's callback: receives echo, calculates latencies.
+        """
+        receive_time = time.perf_counter()
+
+        # Deserialize using bincode
+        _metadata, data = self.serializer.deserialize_message(aerosim_types.JsonData, payload)
+        json_data = data.get_data()
+
+        msg_id = json_data.get("msg_id")
+        original_send_time = json_data.get("original_send_time")
+        node_b_receive_time = json_data.get("node_b_receive_time")
+        node_b_send_time = json_data.get("node_b_send_time")
+
+        if all(v is not None for v in [msg_id, original_send_time, node_b_receive_time, node_b_send_time]):
+            # Skip warmup messages
+            if msg_id >= self.warmup_messages:
+                forward_latency = (node_b_receive_time - original_send_time) * 1000
+                return_latency = (receive_time - node_b_send_time) * 1000
+                roundtrip_latency = (receive_time - original_send_time) * 1000
+
+                with self.lock:
+                    self.forward_latencies_ms.append(forward_latency)
+                    self.return_latencies_ms.append(return_latency)
+                    self.roundtrip_latencies_ms.append(roundtrip_latency)
+
+            with self.lock:
+                self.messages_received += 1
+                if self.messages_received >= self.num_messages + self.warmup_messages:
+                    self.all_received.set()
+
+    def run(self, timeout: float = 60.0) -> LatencyResult:
+        """
+        Run the latency benchmark using bincode serialization.
+
+        Args:
+            timeout: Maximum time to wait for all messages (seconds).
+
+        Returns:
+            LatencyResult with measured latencies.
+        """
+        # Set up raw subscriptions with unique topics
+        self.transport.subscribe_raw(
+            "aerosim::types::JsonData", self.forward_topic, self._node_b_callback
+        )
+        self.transport.subscribe_raw(
+            "aerosim::types::JsonData", self.return_topic, self._node_a_callback
+        )
+
+        # Allow subscriptions to establish
+        time.sleep(1.0)
+
+        # Generate payload
+        payload_str = "x" * self.payload_size
+
+        # Send messages (warmup + actual)
+        total_messages = self.num_messages + self.warmup_messages
+        for i in range(total_messages):
+            send_time = time.perf_counter()
+
+            message_data = aerosim_types.JsonData({
+                "msg_id": i,
+                "send_time": send_time,
+                "payload": payload_str
+            })
+            metadata = aerosim_middleware.Metadata(
+                self.forward_topic, "aerosim::types::JsonData"
+            )
+            payload = self.serializer.serialize_message(metadata, message_data)
+            self.transport.publish_raw("aerosim::types::JsonData", self.forward_topic, payload)
+
+            # Small delay between messages to avoid overwhelming the system
+            time.sleep(0.02)
+
+        # Wait for all messages to complete round-trip
+        if not self.all_received.wait(timeout=timeout):
+            print(f"Warning: Timeout waiting for messages. Received {self.messages_received}/{total_messages}")
+
+        return LatencyResult(
+            forward_latencies_ms=self.forward_latencies_ms.copy(),
+            return_latencies_ms=self.return_latencies_ms.copy(),
+            roundtrip_latencies_ms=self.roundtrip_latencies_ms.copy()
+        )
+
+
+class DetailedLatencyBenchmark:
+    """
+    Benchmarks pub-sub latency with detailed breakdown of serialization vs transport time.
+
+    This measures:
+    - Serialization time (time to encode the message)
+    - Transport time (network transfer time)
+    - Deserialization time (time to decode the message)
+    """
+
+    def __init__(self, transport, transport_name: str = "zenoh", serializer=None,
+                 serializer_name: str = "unknown", num_messages: int = 100,
+                 warmup_messages: int = 10, topic_prefix: str = None, payload_size: int = 64):
+        self.transport = transport
+        self.transport_name = transport_name
+        self.serializer = serializer or get_serializer(transport_name)
+        self.serializer_name = serializer_name
+        self.num_messages = num_messages
+        self.warmup_messages = warmup_messages
+        self.payload_size = payload_size
+
+        # Use transport-appropriate topic separator
+        sep = TOPIC_SEPARATOR
+        self.topic_prefix = topic_prefix or f"benchmark{sep}detailed{sep}{uuid.uuid4().hex[:8]}"
+        self.forward_topic = f"{self.topic_prefix}{sep}forward"
+        self.return_topic = f"{self.topic_prefix}{sep}return"
+
+        # Total latency storage
+        self.forward_latencies_ms: List[float] = []
+        self.return_latencies_ms: List[float] = []
+        self.roundtrip_latencies_ms: List[float] = []
+
+        # Detailed timing breakdown
+        self.forward_serialize_ms: List[float] = []
+        self.forward_transport_ms: List[float] = []
+        self.forward_deserialize_ms: List[float] = []
+        self.return_serialize_ms: List[float] = []
+        self.return_transport_ms: List[float] = []
+        self.return_deserialize_ms: List[float] = []
+
+        # Synchronization
+        self.messages_received = 0
+        self.lock = threading.Lock()
+        self.all_received = threading.Event()
+
+    def _node_b_callback(self, payload: bytes):
+        """
+        Node B's callback: receives forward message, records timing, echoes back.
+        """
+        receive_time = time.perf_counter()
+
+        # Deserialize the incoming message and measure time
+        _metadata, data = self.serializer.deserialize_message(aerosim_types.JsonData, payload)
+        deserialize_done_time = time.perf_counter()
+
+        json_data = data.get_data()
+        msg_id = json_data.get("msg_id")
+        original_send_time = json_data.get("send_time")
+        send_after_serialize_time = json_data.get("send_after_serialize_time")
+
+        if msg_id is not None and original_send_time is not None:
+            # Measure Node B's serialization time
+            serialize_start_time = time.perf_counter()
+            echo_data = aerosim_types.JsonData({
+                "msg_id": msg_id,
+                "original_send_time": original_send_time,
+                "send_after_serialize_time": send_after_serialize_time,
+                "node_b_receive_time": receive_time,
+                "node_b_deserialize_done_time": deserialize_done_time,
+                "node_b_serialize_start_time": serialize_start_time,
+            })
+            echo_metadata = aerosim_middleware.Metadata(
+                self.return_topic, "aerosim::types::JsonData"
+            )
+            echo_payload = self.serializer.serialize_message(echo_metadata, echo_data)
+            serialize_done_time = time.perf_counter()
+
+            # Add the serialize time to the echo data by re-serializing (slight overhead for accuracy)
+            echo_data = aerosim_types.JsonData({
+                "msg_id": msg_id,
+                "original_send_time": original_send_time,
+                "send_after_serialize_time": send_after_serialize_time,
+                "node_b_receive_time": receive_time,
+                "node_b_deserialize_done_time": deserialize_done_time,
+                "node_b_serialize_time_ms": (serialize_done_time - serialize_start_time) * 1000,
+                "node_b_send_after_serialize_time": time.perf_counter(),
+            })
+            echo_payload = self.serializer.serialize_message(echo_metadata, echo_data)
+
+            self.transport.publish_raw("aerosim::types::JsonData", self.return_topic, echo_payload)
+
+    def _node_a_callback(self, payload: bytes):
+        """
+        Node A's callback: receives echo, calculates detailed latencies.
+        """
+        receive_time = time.perf_counter()
+
+        # Deserialize and measure time
+        _metadata, data = self.serializer.deserialize_message(aerosim_types.JsonData, payload)
+        deserialize_done_time = time.perf_counter()
+
+        json_data = data.get_data()
+
+        msg_id = json_data.get("msg_id")
+        original_send_time = json_data.get("original_send_time")
+        send_after_serialize_time = json_data.get("send_after_serialize_time")
+        node_b_receive_time = json_data.get("node_b_receive_time")
+        node_b_deserialize_done_time = json_data.get("node_b_deserialize_done_time")
+        node_b_serialize_time_ms = json_data.get("node_b_serialize_time_ms")
+        node_b_send_after_serialize_time = json_data.get("node_b_send_after_serialize_time")
+
+        required_fields = [
+            msg_id, original_send_time, send_after_serialize_time,
+            node_b_receive_time, node_b_deserialize_done_time,
+            node_b_serialize_time_ms, node_b_send_after_serialize_time
+        ]
+
+        if all(v is not None for v in required_fields):
+            # Skip warmup messages
+            if msg_id >= self.warmup_messages:
+                # Forward leg breakdown
+                forward_transport = (node_b_receive_time - send_after_serialize_time) * 1000
+                forward_deserialize = (node_b_deserialize_done_time - node_b_receive_time) * 1000
+                forward_total = (node_b_deserialize_done_time - original_send_time) * 1000
+
+                # Return leg breakdown
+                return_serialize = node_b_serialize_time_ms
+                return_transport = (receive_time - node_b_send_after_serialize_time) * 1000
+                return_deserialize = (deserialize_done_time - receive_time) * 1000
+                return_total = (deserialize_done_time - node_b_deserialize_done_time) * 1000
+
+                # Round-trip total
+                roundtrip_total = (deserialize_done_time - original_send_time) * 1000
+
+                with self.lock:
+                    # Total latencies
+                    self.forward_latencies_ms.append(forward_total)
+                    self.return_latencies_ms.append(return_total)
+                    self.roundtrip_latencies_ms.append(roundtrip_total)
+
+                    # Forward breakdown (serialize time stored per-message in send loop)
+                    self.forward_transport_ms.append(forward_transport)
+                    self.forward_deserialize_ms.append(forward_deserialize)
+
+                    # Return breakdown
+                    self.return_serialize_ms.append(return_serialize)
+                    self.return_transport_ms.append(return_transport)
+                    self.return_deserialize_ms.append(return_deserialize)
+
+            with self.lock:
+                self.messages_received += 1
+                if self.messages_received >= self.num_messages + self.warmup_messages:
+                    self.all_received.set()
+
+    def run(self, timeout: float = 60.0) -> DetailedLatencyResult:
+        """
+        Run the detailed latency benchmark.
+
+        Args:
+            timeout: Maximum time to wait for all messages (seconds).
+
+        Returns:
+            DetailedLatencyResult with measured latencies and breakdown.
+        """
+        # Set up raw subscriptions with unique topics
+        self.transport.subscribe_raw(
+            "aerosim::types::JsonData", self.forward_topic, self._node_b_callback
+        )
+        self.transport.subscribe_raw(
+            "aerosim::types::JsonData", self.return_topic, self._node_a_callback
+        )
+
+        # Allow subscriptions to establish
+        time.sleep(1.0)
+
+        # Generate payload
+        payload_str = "x" * self.payload_size
+
+        # Track forward serialize times separately
+        forward_serialize_times: List[float] = []
+
+        # Send messages (warmup + actual)
+        total_messages = self.num_messages + self.warmup_messages
+        for i in range(total_messages):
+            send_time = time.perf_counter()
+
+            message_data = aerosim_types.JsonData({
+                "msg_id": i,
+                "send_time": send_time,
+                "payload": payload_str
+            })
+            metadata = aerosim_middleware.Metadata(
+                self.forward_topic, "aerosim::types::JsonData"
+            )
+
+            # Measure serialization time
+            serialize_start = time.perf_counter()
+            payload = self.serializer.serialize_message(metadata, message_data)
+            serialize_done = time.perf_counter()
+
+            # Re-serialize with the timing info included
+            message_data = aerosim_types.JsonData({
+                "msg_id": i,
+                "send_time": send_time,
+                "send_after_serialize_time": serialize_done,
+                "payload": payload_str
+            })
+            payload = self.serializer.serialize_message(metadata, message_data)
+
+            if i >= self.warmup_messages:
+                forward_serialize_times.append((serialize_done - serialize_start) * 1000)
+
+            self.transport.publish_raw("aerosim::types::JsonData", self.forward_topic, payload)
+
+            # Small delay between messages to avoid overwhelming the system
+            time.sleep(0.02)
+
+        # Wait for all messages to complete round-trip
+        if not self.all_received.wait(timeout=timeout):
+            print(f"Warning: Timeout waiting for messages. Received {self.messages_received}/{total_messages}")
+
+        # Store forward serialize times (collected from send loop)
+        self.forward_serialize_ms = forward_serialize_times[:len(self.forward_latencies_ms)]
+
+        return DetailedLatencyResult(
+            forward_latencies_ms=self.forward_latencies_ms.copy(),
+            return_latencies_ms=self.return_latencies_ms.copy(),
+            roundtrip_latencies_ms=self.roundtrip_latencies_ms.copy(),
+            forward_serialize_ms=self.forward_serialize_ms.copy(),
+            forward_transport_ms=self.forward_transport_ms.copy(),
+            forward_deserialize_ms=self.forward_deserialize_ms.copy(),
+            return_serialize_ms=self.return_serialize_ms.copy(),
+            return_transport_ms=self.return_transport_ms.copy(),
+            return_deserialize_ms=self.return_deserialize_ms.copy(),
+        )
+
+
+# Module-level transports to be shared across tests (singleton pattern)
+_transports = {}
+
+
+@pytest.fixture(scope="module")
+def zenoh_transport():
+    """
+    Module-scoped fixture providing the Zenoh transport.
+
+    The transport is created once and shared across all tests in the module.
+    ZenohMiddleware is a singleton, so we don't close it between tests.
+    """
+    global _transports
+    try:
+        _transports["zenoh"] = aerosim_middleware.get_transport("zenoh")
+        yield _transports["zenoh"]
+    except (AttributeError, Exception) as e:
+        pytest.skip(f"Zenoh middleware not available: {e}")
+
+
+@pytest.fixture(scope="module")
+def kafka_transport():
+    """
+    Module-scoped fixture providing the Kafka transport.
+
+    The transport is created once and shared across all tests in the module.
+    """
+    global _transports
+    try:
+        _transports["kafka"] = aerosim_middleware.get_transport("kafka")
+        yield _transports["kafka"]
+    except (AttributeError, Exception) as e:
+        pytest.skip(f"Kafka middleware not available: {e}")
+
+
+@pytest.fixture(scope="module", params=["zenoh", "kafka"])
+def transport(request):
+    """
+    Parameterized fixture providing transport for each middleware type.
+    """
+    transport_name = request.param
+    global _transports
+    try:
+        if transport_name not in _transports:
+            _transports[transport_name] = aerosim_middleware.get_transport(transport_name)
+        return (transport_name, _transports[transport_name])
+    except (AttributeError, Exception) as e:
+        pytest.skip(f"{transport_name.capitalize()} middleware not available: {e}")
+
+
+# =============================================================================
+# Parameterized tests that run for all transports
+# =============================================================================
+
+def test_roundtrip_latency_benchmark(transport, capsys):
+    """
+    Benchmark test for publish-subscribe round-trip latency.
+
+    This test:
+    1. Sets up a publisher and subscriber on two topics
+    2. Sends messages that are echoed back
+    3. Measures and reports forward, return, and round-trip latencies
+    """
+    transport_name, transport_obj = transport
+    benchmark = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                  num_messages=500, warmup_messages=20)
+    result = benchmark.run(timeout=120.0)
+
+    # Print results (visible with pytest -s)
+    result.print_summary(title=f"{transport_name.capitalize()} Publish-Subscribe Latency Benchmark Results")
+
+    # Basic assertions to ensure the test ran correctly
+    assert len(result.roundtrip_latencies_ms) > 0, "No round-trip latency measurements collected"
+    assert len(result.forward_latencies_ms) > 0, "No forward latency measurements collected"
+    assert len(result.return_latencies_ms) > 0, "No return latency measurements collected"
+
+    # Sanity check: latencies should be positive and reasonable (< 1 second)
+    avg_roundtrip = statistics.mean(result.roundtrip_latencies_ms)
+    assert avg_roundtrip > 0, "Average round-trip latency should be positive"
+    assert avg_roundtrip < 1000, f"Average round-trip latency too high: {avg_roundtrip:.3f} ms"
+
+
+def test_latency_small_messages(transport, capsys):
+    """Benchmark with small message payload (64 bytes)."""
+    transport_name, transport_obj = transport
+    benchmark = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                  num_messages=200, warmup_messages=10, payload_size=64)
+    result = benchmark.run(timeout=60.0)
+    result.print_summary(title=f"{transport_name.capitalize()} Small Messages (64 bytes) Latency Benchmark")
+
+    assert len(result.roundtrip_latencies_ms) >= 180, "Expected at least 180 measurements"
+
+
+def test_latency_large_messages(transport, capsys):
+    """Benchmark with large message payload (500 KB)."""
+    transport_name, transport_obj = transport
+    # 500 KB payload
+    payload_size = 500 * 1024
+    benchmark = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                  num_messages=200, warmup_messages=10, payload_size=payload_size)
+    result = benchmark.run(timeout=120.0)
+    result.print_summary(title=f"{transport_name.capitalize()} Large Messages ({payload_size // 1024} KB) Latency Benchmark")
+
+    assert len(result.roundtrip_latencies_ms) >= 180, "Expected at least 180 measurements"
+
+    # Large messages will have higher latency, but should still complete
+    avg_roundtrip = statistics.mean(result.roundtrip_latencies_ms)
+    assert avg_roundtrip > 0, "Average round-trip latency should be positive"
+
+
+@pytest.mark.parametrize("num_messages", [50, 200, 500])
+def test_latency_varying_load(transport, num_messages, capsys):
+    """Benchmark with varying number of messages to see if latency changes under load."""
+    transport_name, transport_obj = transport
+    benchmark = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                  num_messages=num_messages, warmup_messages=10)
+    result = benchmark.run(timeout=120.0)
+
+    print(f"\n--- {transport_name.capitalize()} Results for {num_messages} messages ---")
+    if result.roundtrip_latencies_ms:
+        avg = statistics.mean(result.roundtrip_latencies_ms)
+        print(f"Average round-trip latency: {avg:.3f} ms")
+
+    assert len(result.roundtrip_latencies_ms) > 0
+
+
+def test_latency_large_messages_bincode(transport, capsys):
+    """Benchmark large messages with bincode serialization (compare to JSON)."""
+    transport_name, transport_obj = transport
+    payload_size = 500 * 1024  # 500 KB
+
+    # First run with JSON (standard)
+    print(f"\n--- {transport_name.capitalize()} JSON Serialization (500 KB payload) ---")
+    benchmark_json = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                       num_messages=100, warmup_messages=10, payload_size=payload_size)
+    result_json = benchmark_json.run(timeout=120.0)
+    result_json.print_summary(title=f"{transport_name.capitalize()} Large Messages - JSON Serialization (500 KB)")
+
+    # Then run with Bincode
+    print(f"\n--- {transport_name.capitalize()} Bincode Serialization (500 KB payload) ---")
+    benchmark_bincode = LatencyBenchmarkBincode(transport_obj, transport_name=transport_name,
+                                                  num_messages=100, warmup_messages=10, payload_size=payload_size)
+    result_bincode = benchmark_bincode.run(timeout=120.0)
+    result_bincode.print_summary(title=f"{transport_name.capitalize()} Large Messages - Bincode Serialization (500 KB)")
+
+    # Print comparison
+    if result_json.roundtrip_latencies_ms and result_bincode.roundtrip_latencies_ms:
+        avg_json = statistics.mean(result_json.roundtrip_latencies_ms)
+        avg_bincode = statistics.mean(result_bincode.roundtrip_latencies_ms)
+        improvement = ((avg_json - avg_bincode) / avg_json) * 100
+
+        print("\n" + "=" * 60)
+        print(f"{transport_name.capitalize()} Serialization Comparison (500 KB payload)")
+        print("=" * 60)
+        print(f"  JSON avg round-trip:    {avg_json:.3f} ms")
+        print(f"  Bincode avg round-trip: {avg_bincode:.3f} ms")
+        print(f"  Difference:             {avg_json - avg_bincode:.3f} ms ({improvement:+.1f}%)")
+        print("=" * 60)
+
+    assert len(result_json.roundtrip_latencies_ms) > 0
+    assert len(result_bincode.roundtrip_latencies_ms) > 0
+
+
+def test_latency_detailed_breakdown(transport, capsys):
+    """Benchmark with detailed serialization vs transport time breakdown."""
+    transport_name, transport_obj = transport
+    payload_size = 500 * 1024  # 500 KB
+
+    # Run detailed benchmark with transport-specific JSON serializer
+    print(f"\n--- {transport_name.capitalize()} JSON Serializer Detailed Breakdown (500 KB payload) ---")
+    json_serializer = get_serializer(transport_name)
+    benchmark_json = DetailedLatencyBenchmark(
+        transport_obj,
+        transport_name=transport_name,
+        serializer=json_serializer,
+        serializer_name="JSON",
+        num_messages=100,
+        warmup_messages=10,
+        payload_size=payload_size
+    )
+    result_json = benchmark_json.run(timeout=120.0)
+    result_json.print_summary(title=f"{transport_name.capitalize()} JSON Serializer - Detailed Breakdown (500 KB)")
+
+    # Run detailed benchmark with Bincode serializer
+    print(f"\n--- {transport_name.capitalize()} Bincode Serializer Detailed Breakdown (500 KB payload) ---")
+    bincode_serializer = aerosim_middleware.BincodeSerializer()
+    benchmark_bincode = DetailedLatencyBenchmark(
+        transport_obj,
+        transport_name=transport_name,
+        serializer=bincode_serializer,
+        serializer_name="Bincode",
+        num_messages=100,
+        warmup_messages=10,
+        payload_size=payload_size
+    )
+    result_bincode = benchmark_bincode.run(timeout=120.0)
+    result_bincode.print_summary(title=f"{transport_name.capitalize()} Bincode Serializer - Detailed Breakdown (500 KB)")
+
+    # Print comparison summary
+    if result_json.roundtrip_latencies_ms and result_bincode.roundtrip_latencies_ms:
+        print("\n" + "=" * 70)
+        print(f"{transport_name.capitalize()} Serialization vs Transport Comparison (500 KB payload)")
+        print("=" * 70)
+
+        # JSON totals
+        json_serialize = (
+            statistics.mean(result_json.forward_serialize_ms) +
+            statistics.mean(result_json.return_serialize_ms)
+        )
+        json_transport_time = (
+            statistics.mean(result_json.forward_transport_ms) +
+            statistics.mean(result_json.return_transport_ms)
+        )
+        json_deserialize = (
+            statistics.mean(result_json.forward_deserialize_ms) +
+            statistics.mean(result_json.return_deserialize_ms)
+        )
+        json_total = statistics.mean(result_json.roundtrip_latencies_ms)
+
+        # Bincode totals
+        bincode_serialize = (
+            statistics.mean(result_bincode.forward_serialize_ms) +
+            statistics.mean(result_bincode.return_serialize_ms)
+        )
+        bincode_transport_time = (
+            statistics.mean(result_bincode.forward_transport_ms) +
+            statistics.mean(result_bincode.return_transport_ms)
+        )
+        bincode_deserialize = (
+            statistics.mean(result_bincode.forward_deserialize_ms) +
+            statistics.mean(result_bincode.return_deserialize_ms)
+        )
+        bincode_total = statistics.mean(result_bincode.roundtrip_latencies_ms)
+
+        print(f"\n{'Component':<20} {'JSON (ms)':<15} {'Bincode (ms)':<15} {'Diff (ms)':<15}")
+        print("-" * 65)
+        print(f"{'Serialize':<20} {json_serialize:<15.3f} {bincode_serialize:<15.3f} {json_serialize - bincode_serialize:<+15.3f}")
+        print(f"{'Transport':<20} {json_transport_time:<15.3f} {bincode_transport_time:<15.3f} {json_transport_time - bincode_transport_time:<+15.3f}")
+        print(f"{'Deserialize':<20} {json_deserialize:<15.3f} {bincode_deserialize:<15.3f} {json_deserialize - bincode_deserialize:<+15.3f}")
+        print("-" * 65)
+        print(f"{'Total Round-Trip':<20} {json_total:<15.3f} {bincode_total:<15.3f} {json_total - bincode_total:<+15.3f}")
+        print("=" * 70)
+
+    assert len(result_json.roundtrip_latencies_ms) > 0
+    assert len(result_bincode.roundtrip_latencies_ms) > 0
+
+
+if __name__ == "__main__":
+    # Allow running directly for quick testing
+    import sys
+
+    # Default to zenoh, but allow specifying transport via command line
+    transport_name = sys.argv[1] if len(sys.argv) > 1 else "zenoh"
+
+    print(f"Running {transport_name.capitalize()} latency benchmark...")
+    transport_obj = aerosim_middleware.get_transport(transport_name)
+
+    # Small messages benchmark
+    print("\n*** Small Messages (64 bytes) ***")
+    benchmark = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                  num_messages=200, warmup_messages=10, payload_size=64)
+    result = benchmark.run()
+    result.print_summary(title=f"{transport_name.capitalize()} Small Messages (64 bytes)")
+
+    # Large messages benchmark
+    print("\n*** Large Messages (500 KB) ***")
+    benchmark = LatencyBenchmark(transport_obj, transport_name=transport_name,
+                                  num_messages=100, warmup_messages=10, payload_size=500 * 1024)
+    result = benchmark.run(timeout=120.0)
+    result.print_summary(title=f"{transport_name.capitalize()} Large Messages (500 KB)")

--- a/aerosim-data/tests/test_latency_benchmark_minimal.py
+++ b/aerosim-data/tests/test_latency_benchmark_minimal.py
@@ -1,0 +1,227 @@
+"""
+Minimal latency benchmark for middleware pub/sub round-trip timing.
+
+A simple, readable benchmark that measures round-trip latency between two nodes
+with detailed breakdown of serialization, transport, and deserialization times.
+
+Uses the raw publish/subscribe API with explicit serialization for clarity.
+
+Run with:
+    pytest test_latency_benchmark_minimal.py -v -s
+    pytest test_latency_benchmark_minimal.py -v -s -k "zenoh"
+    pytest test_latency_benchmark_minimal.py -v -s -k "kafka"
+
+Configure via constants below: PAYLOAD_SIZE_BYTES, NUM_MESSAGES, USE_BINCODE
+"""
+import pytest
+import time
+import threading
+import uuid
+import statistics
+
+from aerosim_data import middleware as mw
+from aerosim_data import types as aerosim_types
+
+# =============================================================================
+# CONFIGURATION - Modify these to change benchmark parameters
+# =============================================================================
+PAYLOAD_SIZE_BYTES = 1024      # Size of test payload (e.g., 64, 1024, 512000)
+NUM_MESSAGES = 1               # Number of round-trips to measure
+USE_BINCODE = False            # True for bincode, False for JSON serialization
+# =============================================================================
+
+DATA_TYPE = "aerosim::types::JsonData"
+
+
+def get_serializer(transport_name: str):
+    """Get the appropriate serializer based on configuration."""
+    if USE_BINCODE:
+        return mw.BincodeSerializer()
+    elif transport_name == "zenoh":
+        return mw.ZenohSerializer()
+    else:
+        return mw.KafkaSerializer()
+
+
+@pytest.fixture(scope="module", params=["zenoh", "kafka"])
+def transport(request):
+    """Create middleware transport for the test."""
+    transport_name = request.param
+    if transport_name == "zenoh":
+        transport_obj = mw.ZenohMiddleware()
+    else:
+        transport_obj = mw.KafkaMiddleware()
+    yield transport_name, transport_obj
+    transport_obj.close()
+
+
+def test_minimal_roundtrip_latency(transport):
+    """
+    Minimal round-trip latency benchmark using raw pub/sub API.
+
+    Timing breakdown:
+        Forward: serialize_a -> transport_ab -> deserialize_b
+        Return:  serialize_b -> transport_ba -> deserialize_a
+    """
+    transport_name, middleware = transport
+    serializer = get_serializer(transport_name)
+
+    # Create unique topic names for this test run
+    test_id = uuid.uuid4().hex[:8]
+    forward_topic = f"bench-{test_id}-fwd"
+    return_topic = f"bench-{test_id}-ret"
+
+    # Create test payload
+    payload_str = "x" * PAYLOAD_SIZE_BYTES
+
+    # Storage for detailed measurements (each entry is a dict of timings)
+    measurements = []
+    roundtrip_complete = threading.Event()
+
+    # --- Node B: Echo service ---
+    def echo_callback(raw_bytes: bytes):
+        """Receive on forward topic, deserialize, re-serialize, publish to return."""
+        t_recv_b = time.perf_counter()
+
+        # Deserialize incoming message
+        _metadata, data = serializer.deserialize_message(aerosim_types.JsonData, raw_bytes)
+        t_deser_b = time.perf_counter()
+
+        json_data = data.get_data()
+
+        # Create echo with timing data
+        echo_data = aerosim_types.JsonData({
+            # Forward leg timings from Node A
+            "t_start_a": json_data.get("t_start_a"),
+            "t_ser_a": json_data.get("t_ser_a"),
+            # Forward leg timings from Node B
+            "t_recv_b": t_recv_b,
+            "t_deser_b": t_deser_b,
+        })
+
+        # Serialize echo
+        metadata = mw.Metadata(return_topic, DATA_TYPE)
+        echo_bytes = serializer.serialize_message(metadata, echo_data)
+        t_ser_b = time.perf_counter()
+
+        # Update echo with serialize time and publish
+        echo_data = aerosim_types.JsonData({
+            "t_start_a": json_data.get("t_start_a"),
+            "t_ser_a": json_data.get("t_ser_a"),
+            "t_recv_b": t_recv_b,
+            "t_deser_b": t_deser_b,
+            "t_ser_b": t_ser_b,
+        })
+        echo_bytes = serializer.serialize_message(metadata, echo_data)
+
+        middleware.publish_raw(DATA_TYPE, return_topic, echo_bytes)
+
+    # --- Node A: Latency measurer ---
+    def measure_callback(raw_bytes: bytes):
+        """Receive echo, deserialize, calculate detailed latencies."""
+        t_recv_a = time.perf_counter()
+
+        # Deserialize echo message
+        _metadata, data = serializer.deserialize_message(aerosim_types.JsonData, raw_bytes)
+        t_deser_a = time.perf_counter()
+
+        json_data = data.get_data()
+
+        # Extract all timestamps
+        t_start_a = json_data.get("t_start_a", 0)
+        t_ser_a = json_data.get("t_ser_a", 0)
+        t_recv_b = json_data.get("t_recv_b", 0)
+        t_deser_b = json_data.get("t_deser_b", 0)
+        t_ser_b = json_data.get("t_ser_b", 0)
+
+        # Calculate timing breakdown (in ms)
+        measurements.append({
+            # Forward leg
+            "serialize_a": (t_ser_a - t_start_a) * 1000,
+            "transport_ab": (t_recv_b - t_ser_a) * 1000,
+            "deserialize_b": (t_deser_b - t_recv_b) * 1000,
+            # Return leg
+            "serialize_b": (t_ser_b - t_deser_b) * 1000,
+            "transport_ba": (t_recv_a - t_ser_b) * 1000,
+            "deserialize_a": (t_deser_a - t_recv_a) * 1000,
+            # Totals
+            "roundtrip": (t_deser_a - t_start_a) * 1000,
+        })
+        roundtrip_complete.set()
+
+    # Set up subscriptions
+    middleware.subscribe_raw(DATA_TYPE, forward_topic, echo_callback)
+    middleware.subscribe_raw(DATA_TYPE, return_topic, measure_callback)
+
+    # Wait for subscriptions to be ready
+    time.sleep(1.0)
+
+    # --- Run the benchmark ---
+    serialization_type = "Bincode" if USE_BINCODE else "JSON"
+    print(f"\n{'='*60}")
+    print(f"{transport_name.upper()} Minimal Latency Benchmark")
+    print(f"Payload: {PAYLOAD_SIZE_BYTES} bytes | Serialization: {serialization_type}")
+    print(f"{'='*60}")
+
+    # Warmup loop (not measured)
+    roundtrip_complete.clear()
+    t_start = time.perf_counter()
+    warmup_msg = aerosim_types.JsonData({
+        "t_start_a": t_start,
+        "t_ser_a": t_start,
+        "payload": payload_str
+    })
+    metadata = mw.Metadata(forward_topic, DATA_TYPE)
+    raw_bytes = serializer.serialize_message(metadata, warmup_msg)
+    middleware.publish_raw(DATA_TYPE, forward_topic, raw_bytes)
+    roundtrip_complete.wait(timeout=30.0)
+    measurements.clear()  # Discard warmup measurement
+
+    # Measured loops
+    for i in range(NUM_MESSAGES):
+        roundtrip_complete.clear()
+
+        # Create message with timestamp and payload
+        t_start_a = time.perf_counter()
+        message = aerosim_types.JsonData({
+            "t_start_a": t_start_a,
+            "payload": payload_str
+        })
+
+        # Serialize
+        metadata = mw.Metadata(forward_topic, DATA_TYPE)
+        raw_bytes = serializer.serialize_message(metadata, message)
+        t_ser_a = time.perf_counter()
+
+        # Update message with serialization end time and re-serialize
+        message = aerosim_types.JsonData({
+            "t_start_a": t_start_a,
+            "t_ser_a": t_ser_a,
+            "payload": payload_str
+        })
+        raw_bytes = serializer.serialize_message(metadata, message)
+
+        # Publish
+        middleware.publish_raw(DATA_TYPE, forward_topic, raw_bytes)
+
+        # Wait for this message to complete round-trip before sending next
+        if not roundtrip_complete.wait(timeout=30.0):
+            print(f"Timeout waiting for message {i}")
+            break
+
+    # --- Print results ---
+    if measurements:
+        avg_label = " (ave)" if len(measurements) > 1 else ""
+        print(f"\nDetailed Latency Breakdown ({len(measurements)} samples):")
+        print("\nForward (A -> B):")
+        print(f"  Serialize A:   {statistics.mean([m['serialize_a'] for m in measurements]):.3f} ms{avg_label}")
+        print(f"  Transport A→B: {statistics.mean([m['transport_ab'] for m in measurements]):.3f} ms{avg_label}")
+        print(f"  Deserialize B: {statistics.mean([m['deserialize_b'] for m in measurements]):.3f} ms{avg_label}")
+        print("\nReturn (B -> A):")
+        print(f"  Serialize B:   {statistics.mean([m['serialize_b'] for m in measurements]):.3f} ms{avg_label}")
+        print(f"  Transport B→A: {statistics.mean([m['transport_ba'] for m in measurements]):.3f} ms{avg_label}")
+        print(f"  Deserialize A: {statistics.mean([m['deserialize_a'] for m in measurements]):.3f} ms{avg_label}")
+        print(f"\nTotal Round-Trip: {statistics.mean([m['roundtrip'] for m in measurements]):.3f} ms{avg_label}")
+        print(f"{'='*60}\n")
+
+    assert len(measurements) >= NUM_MESSAGES, f"Too few responses: {len(measurements)}/{NUM_MESSAGES}"

--- a/aerosim-data/tests/test_latency_benchmark_minimal.py
+++ b/aerosim-data/tests/test_latency_benchmark_minimal.py
@@ -78,41 +78,23 @@ def test_minimal_roundtrip_latency(transport):
     measurements = []
     roundtrip_complete = threading.Event()
 
+    # Shared timing data (avoids double serialization)
+    timing = {}
+
     # --- Node B: Echo service ---
     def echo_callback(raw_bytes: bytes):
         """Receive on forward topic, deserialize, re-serialize, publish to return."""
-        t_recv_b = time.perf_counter()
+        timing["t_recv_b"] = time.perf_counter()
 
         # Deserialize incoming message
-        _metadata, data = serializer.deserialize_message(aerosim_types.JsonData, raw_bytes)
-        t_deser_b = time.perf_counter()
+        _metadata, _data = serializer.deserialize_message(aerosim_types.JsonData, raw_bytes)
+        timing["t_deser_b"] = time.perf_counter()
 
-        json_data = data.get_data()
-
-        # Create echo with timing data
-        echo_data = aerosim_types.JsonData({
-            # Forward leg timings from Node A
-            "t_start_a": json_data.get("t_start_a"),
-            "t_ser_a": json_data.get("t_ser_a"),
-            # Forward leg timings from Node B
-            "t_recv_b": t_recv_b,
-            "t_deser_b": t_deser_b,
-        })
-
-        # Serialize echo
+        # Create and serialize echo (payload only, timestamps stored in shared dict)
+        echo_data = aerosim_types.JsonData({"payload": payload_str})
         metadata = mw.Metadata(return_topic, DATA_TYPE)
         echo_bytes = serializer.serialize_message(metadata, echo_data)
-        t_ser_b = time.perf_counter()
-
-        # Update echo with serialize time and publish
-        echo_data = aerosim_types.JsonData({
-            "t_start_a": json_data.get("t_start_a"),
-            "t_ser_a": json_data.get("t_ser_a"),
-            "t_recv_b": t_recv_b,
-            "t_deser_b": t_deser_b,
-            "t_ser_b": t_ser_b,
-        })
-        echo_bytes = serializer.serialize_message(metadata, echo_data)
+        timing["t_ser_b"] = time.perf_counter()
 
         middleware.publish_raw(DATA_TYPE, return_topic, echo_bytes)
 
@@ -122,30 +104,21 @@ def test_minimal_roundtrip_latency(transport):
         t_recv_a = time.perf_counter()
 
         # Deserialize echo message
-        _metadata, data = serializer.deserialize_message(aerosim_types.JsonData, raw_bytes)
+        _metadata, _data = serializer.deserialize_message(aerosim_types.JsonData, raw_bytes)
         t_deser_a = time.perf_counter()
 
-        json_data = data.get_data()
-
-        # Extract all timestamps
-        t_start_a = json_data.get("t_start_a", 0)
-        t_ser_a = json_data.get("t_ser_a", 0)
-        t_recv_b = json_data.get("t_recv_b", 0)
-        t_deser_b = json_data.get("t_deser_b", 0)
-        t_ser_b = json_data.get("t_ser_b", 0)
-
-        # Calculate timing breakdown (in ms)
+        # Calculate timing breakdown using shared dict (in ms)
         measurements.append({
             # Forward leg
-            "serialize_a": (t_ser_a - t_start_a) * 1000,
-            "transport_ab": (t_recv_b - t_ser_a) * 1000,
-            "deserialize_b": (t_deser_b - t_recv_b) * 1000,
+            "serialize_a": (timing["t_ser_a"] - timing["t_start_a"]) * 1000,
+            "transport_ab": (timing["t_recv_b"] - timing["t_ser_a"]) * 1000,
+            "deserialize_b": (timing["t_deser_b"] - timing["t_recv_b"]) * 1000,
             # Return leg
-            "serialize_b": (t_ser_b - t_deser_b) * 1000,
-            "transport_ba": (t_recv_a - t_ser_b) * 1000,
+            "serialize_b": (timing["t_ser_b"] - timing["t_deser_b"]) * 1000,
+            "transport_ba": (t_recv_a - timing["t_ser_b"]) * 1000,
             "deserialize_a": (t_deser_a - t_recv_a) * 1000,
             # Totals
-            "roundtrip": (t_deser_a - t_start_a) * 1000,
+            "roundtrip": (t_deser_a - timing["t_start_a"]) * 1000,
         })
         roundtrip_complete.set()
 
@@ -165,14 +138,11 @@ def test_minimal_roundtrip_latency(transport):
 
     # Warmup loop (not measured)
     roundtrip_complete.clear()
-    t_start = time.perf_counter()
-    warmup_msg = aerosim_types.JsonData({
-        "t_start_a": t_start,
-        "t_ser_a": t_start,
-        "payload": payload_str
-    })
+    timing["t_start_a"] = time.perf_counter()
+    warmup_msg = aerosim_types.JsonData({"payload": payload_str})
     metadata = mw.Metadata(forward_topic, DATA_TYPE)
     raw_bytes = serializer.serialize_message(metadata, warmup_msg)
+    timing["t_ser_a"] = time.perf_counter()
     middleware.publish_raw(DATA_TYPE, forward_topic, raw_bytes)
     roundtrip_complete.wait(timeout=30.0)
     measurements.clear()  # Discard warmup measurement
@@ -181,25 +151,14 @@ def test_minimal_roundtrip_latency(transport):
     for i in range(NUM_MESSAGES):
         roundtrip_complete.clear()
 
-        # Create message with timestamp and payload
-        t_start_a = time.perf_counter()
-        message = aerosim_types.JsonData({
-            "t_start_a": t_start_a,
-            "payload": payload_str
-        })
+        # Create message with payload (timestamps stored in shared dict)
+        timing["t_start_a"] = time.perf_counter()
+        message = aerosim_types.JsonData({"payload": payload_str})
 
         # Serialize
         metadata = mw.Metadata(forward_topic, DATA_TYPE)
         raw_bytes = serializer.serialize_message(metadata, message)
-        t_ser_a = time.perf_counter()
-
-        # Update message with serialization end time and re-serialize
-        message = aerosim_types.JsonData({
-            "t_start_a": t_start_a,
-            "t_ser_a": t_ser_a,
-            "payload": payload_str
-        })
-        raw_bytes = serializer.serialize_message(metadata, message)
+        timing["t_ser_a"] = time.perf_counter()
 
         # Publish
         middleware.publish_raw(DATA_TYPE, forward_topic, raw_bytes)


### PR DESCRIPTION
## Summary

Add latency benchmarks for measuring Zenoh and Kafka middleware pub/sub round-trip timing with detailed breakdown of serialization, transport, and deserialization times.

## Changes

### Unified Latency Benchmark
- `aerosim-data/examples/latency_benchmark.rs` - Rust implementation
- `aerosim-data/tests/test_latency_benchmark.py` - Python implementation (pytest)

Comprehensive benchmark suite with:
- Small messages (64 bytes), standard (1KB), and large (500KB) payload tests
- JSON vs Bincode serialization comparison
- Detailed timing breakdown (serialize/transport/deserialize per leg)
- Varying load tests (50/200/500 messages)

### Minimal Latency Benchmark
- `aerosim-data/examples/latency_benchmark_minimal.rs` - Rust implementation
- `aerosim-data/tests/test_latency_benchmark_minimal.py` - Python implementation

Simple, readable benchmark for quick latency checks:
- Configurable via constants: `PAYLOAD_SIZE_BYTES`, `NUM_MESSAGES`, `USE_BINCODE`
- Uses raw publish/subscribe API with explicit serialization
- Sequential round-trip measurement (waits for each message to complete)
- Warmup loop to absorb initial connection overhead
- Shared timing data structure to avoid double serialization

## Usage

**Minimal benchmark:**
```bash
# Rust
cargo run --example latency_benchmark_minimal -- zenoh
cargo run --example latency_benchmark_minimal -- kafka

# Python
pytest tests/test_latency_benchmark_minimal.py -v -s -k "zenoh"
pytest tests/test_latency_benchmark_minimal.py -v -s -k "kafka"
