### PR TITLE
Runtime fixes with Omniverse Kit 107.3

### DIFF
--- a/dev_scripts/config/sim_config_daa_collision.json
+++ b/dev_scripts/config/sim_config_daa_collision.json
@@ -179,7 +179,7 @@
                         }
                     },
                     {
-                        "id": "tilrotor_1",
+                        "id": "tiltrotor_1",
                         "relative_path": "generic_evtol/tiltrotor_1",
                         "transform": {
                             "translation": [
@@ -457,7 +457,7 @@
                         }
                     },
                     {
-                        "id": "tilrotor_1",
+                        "id": "tiltrotor_1",
                         "relative_path": "generic_evtol/tiltrotor_1",
                         "transform": {
                             "translation": [

--- a/dev_scripts/config/sim_config_flyby_intruders.json
+++ b/dev_scripts/config/sim_config_flyby_intruders.json
@@ -109,7 +109,7 @@
                 "effectors": [
                     {
                         "id": "propeller_front",
-                        "relative_path": "vehicle/propeller",
+                        "relative_path": "generic_airplane/propeller",
                         "transform": {
                             "translation": [
                                 0.0,
@@ -163,7 +163,7 @@
                 "effectors": [
                     {
                         "id": "propeller_front",
-                        "relative_path": "vehicle/propeller",
+                        "relative_path": "generic_airplane/propeller",
                         "transform": {
                             "translation": [
                                 0.0,
@@ -217,7 +217,7 @@
                 "effectors": [
                     {
                         "id": "propeller_front",
-                        "relative_path": "vehicle/propeller",
+                        "relative_path": "generic_airplane/propeller",
                         "transform": {
                             "translation": [
                                 0.0,
@@ -271,7 +271,7 @@
                 "effectors": [
                     {
                         "id": "propeller_front",
-                        "relative_path": "vehicle/propeller",
+                        "relative_path": "generic_airplane/propeller",
                         "transform": {
                             "translation": [
                                 0.0,
@@ -325,7 +325,7 @@
                 "effectors": [
                     {
                         "id": "propeller_front",
-                        "relative_path": "vehicle/propeller",
+                        "relative_path": "generic_airplane/propeller",
                         "transform": {
                             "translation": [
                                 0.0,

--- a/examples/config/sim_config_autopilot_daa_scenario.json
+++ b/examples/config/sim_config_autopilot_daa_scenario.json
@@ -242,7 +242,7 @@
                         }
                     },
                     {
-                        "id": "tilrotor_1",
+                        "id": "tiltrotor_1",
                         "relative_path": "generic_evtol/tiltrotor_1",
                         "transform": {
                             "translation": [

--- a/examples/config/sim_config_autopilot_daa_scenario.json
+++ b/examples/config/sim_config_autopilot_daa_scenario.json
@@ -401,7 +401,7 @@
                 "effectors": [
                     {
                         "id": "propeller_front",
-                        "relative_path": "vehicle/propeller",
+                        "relative_path": "generic_airplane/propeller",
                         "transform": {
                             "translation": [
                                 0.0,


### PR DESCRIPTION
## Summary
- **Fix effector id typo**: Corrected `"tilrotor_1"` to `"tiltrotor_1"` in effector definitions, fixing effector lookup failures at runtime
- **Fix propeller effector relative_path**: Changed `"vehicle/propeller"` to `"generic_airplane/propeller"` to match the actual USD prim hierarchy, fixing "Failed to get effector actor prim" errors for intruder aircraft

## Files changed
- `dev_scripts/config/sim_config_daa_collision.json` — fix `tilrotor_1` typo (2 occurrences)
- `dev_scripts/config/sim_config_flyby_intruders.json` — fix propeller `relative_path` (5 occurrences)
- `examples/config/sim_config_autopilot_daa_scenario.json` — fix `tilrotor_1` typo (1 occurrence) and propeller `relative_path` (1 occurrence)

## Test plan
- [x] Launch DAA scenario and verify tiltrotor and propeller effectors resolve correctly
