### PR TITLE
Reloading scenarios without restarting renderers

### DIFF
--- a/aerosim-world-link/src/message_handler.rs
+++ b/aerosim-world-link/src/message_handler.rs
@@ -508,6 +508,22 @@ fn handle_orchestrator_command_message(
             raw_payload: serde_json::to_string(&filtered_scene_graph)
                 .expect("Error serializing sene_graph message to JSON."),
         });
+    } else if command_str == "stop" {
+        info!(
+            "[aerosim.world.link] Processing stop command for renderer with Instance ID: {}.",
+            instance_id
+        );
+
+        // Forward the stop command to the payload queue so the renderer can detect it
+        let payload_timestamp: f64 = metadata.timestamp_platform.sec as f64
+            + metadata.timestamp_platform.nanosec as f64 / 1_000_000_000.0;
+
+        let mut payload_queue_lock = payload_queue.lock().unwrap();
+        payload_queue_lock.push(Payload {
+            timestamp: payload_timestamp,
+            raw_payload: serde_json::to_string(&msg_data)
+                .expect("Error serializing stop command to JSON."),
+        });
     }
 }
 

--- a/examples/first_flight.py
+++ b/examples/first_flight.py
@@ -259,12 +259,12 @@ class FirstFlight:
         autopilot_command = aerosim_types.AutopilotCommand(**self.ap_cmd)
         self.transport.publish(self.ap_cmd_topic, autopilot_command)
 
-    def run(self):
+    def run(self, stop_event):
         """Run the simulation loop"""
         logger.info("Starting simulation loop")
 
         try:
-            while self.running:
+            while self.running and not stop_event.is_set():
                 # Process any commands from aerosim-app
                 if command_queue:
                     with self.lock:
@@ -280,9 +280,11 @@ class FirstFlight:
             # Clean up
             if self.aerosim:
                 self.aerosim.stop()
+            if self.transport:
+                self.transport.close()
             logger.info("Simulation stopped")
 
-def run_simulation():
+def run_simulation(stop_event):
     """Run the simulation in a separate thread"""
     # Create the application
     program = FirstFlight()
@@ -292,7 +294,7 @@ def run_simulation():
         program.init()
 
         # Run the simulation loop
-        program.run()
+        program.run(stop_event)
     except Exception as e:
         logger.error(f"Error in simulation: {e}")
         traceback.print_exc()
@@ -315,7 +317,8 @@ async def run_websocket_servers():
 if __name__ == "__main__":
     try:
         # Start the simulation in a separate thread
-        sim_thread = threading.Thread(target=run_simulation, daemon=True)
+        stop_event = threading.Event()
+        sim_thread = threading.Thread(target=run_simulation, args=(stop_event,), daemon=True)
         sim_thread.start()
 
         # Start the WebSocket server in the main asyncio event loop
@@ -325,3 +328,7 @@ if __name__ == "__main__":
     except Exception as e:
         logger.error(f"Error: {e}")
         traceback.print_exc()
+    finally:
+        logger.info("Stopping simulation...")
+        stop_event.set()
+        sim_thread.join()

--- a/examples/pilot_control_with_flight_deck.py
+++ b/examples/pilot_control_with_flight_deck.py
@@ -337,12 +337,12 @@ class App:
             self.current_speed = cur_speed
             self.current_altitude = cur_altitude
 
-    def loop(self) -> None:
+    def loop(self, stop_event) -> None:
         """Main control loop for processing commands and updating simulation"""
         running = True
 
         try:
-            while running:
+            while running and not stop_event.is_set():
                 with self.lock:
                     veh_state_str = f"Alt: {self.current_altitude:.0f} ft Spd: {self.current_speed:.0f} ft/s"
 
@@ -488,20 +488,23 @@ async def run_websocket_servers():
     await asyncio.gather(*websocket_tasks)
 
 
-def run_simulation() -> None:
+def run_simulation(stop_event) -> None:
     """Run the simulation in a separate thread"""
     app = App()
     try:
         app.init()
-        app.loop()
+        app.loop(stop_event)
     finally:
         app.stop()
+        if app.transport:
+            app.transport.close()
 
 
 if __name__ == "__main__":
     try:
         # Start the simulation in a separate thread
-        sim_thread = threading.Thread(target=run_simulation, daemon=True)
+        stop_event = threading.Event()
+        sim_thread = threading.Thread(target=run_simulation, args=(stop_event,), daemon=True)
         sim_thread.start()
 
         # Start the WebSocket server in the main asyncio event loop
@@ -511,3 +514,7 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Unexpected error: {e}")
         traceback.print_exc()
+    finally:
+        print("Stopping simulation...")
+        stop_event.set()
+        sim_thread.join()


### PR DESCRIPTION
## Summary
- Forward the orchestrator `stop` command through the world-link payload queue so renderers can detect it and reload their scene
- Fix clean shutdown on Ctrl-C for `first_flight.py` and `pilot_control_with_flight_deck.py` example scripts

## Details

### World-link stop command forwarding

Previously, the `stop` command received on `aerosim.orchestrator.commands` was handled by the Rust message handler but not forwarded to the renderer's consumer payload queue. Renderers had no way to know the scenario had ended.

Now the stop command JSON is pushed to the payload queue like other messages, allowing renderers (Omniverse Kit, Unreal) to detect it during their update loop and trigger a scene/level reload to be ready for the next scenario.

### Example script clean shutdown

`first_flight.py` and `pilot_control_with_flight_deck.py` used daemon threads without a shutdown signal, so Ctrl-C killed the sim thread before it could run cleanup (`aerosim.stop()`, `transport.close()`). This prevented the orchestrator from sending the `stop` command to renderers.

Both scripts now match the pattern from `autopilot_daa_scenario.py`:
- `threading.Event` signals the sim thread to exit its loop
- `finally` block in `__main__` sets the event and joins the thread
- `transport.close()` added to cleanup paths

## Test plan
- [x] Run `first_flight.py`, Ctrl-C cleanly stops the sim and orchestrator sends `stop` to renderers
- [x] Run `pilot_control_with_flight_deck.py`, Ctrl-C cleanly stops the sim and orchestrator sends `stop` to renderers
- [x] Run `autopilot_daa_scenario.py`, verify no regression in existing clean shutdown behavior
