### PR TITLE
Camera sensor image fix

### DIFF
--- a/aerosim-world-link/src/lib.rs
+++ b/aerosim-world-link/src/lib.rs
@@ -219,6 +219,10 @@ pub extern "C" fn publish_image_to_topic(
         encoding, // Hardcoded to BGRA on the renderer side.
         is_bigendian: 0,
         step: (width * 4) as u32, // Assuming there is no padding
+        // IMPORTANT: Must use Cow::Owned to copy the data. The `data` pointer comes from
+        // a GPU memory mapping that is unlocked/invalidated after this FFI call returns.
+        // The image is sent to an async channel and compressed later, so using Cow::Borrowed
+        // would create a use-after-free bug causing image corruption (horizontal black bands).
         data: Cow::Owned(image_data.to_vec()),
     };
 

--- a/aerosim-world-link/src/lib.rs
+++ b/aerosim-world-link/src/lib.rs
@@ -219,7 +219,7 @@ pub extern "C" fn publish_image_to_topic(
         encoding, // Hardcoded to BGRA on the renderer side.
         is_bigendian: 0,
         step: (width * 4) as u32, // Assuming there is no padding
-        data: Cow::Borrowed(image_data),
+        data: Cow::Owned(image_data.to_vec()),
     };
 
     info!("[aerosim.renderer] Publishing message: {} ", topic_str);

--- a/dev_scripts/camera_stream_opencv.py
+++ b/dev_scripts/camera_stream_opencv.py
@@ -3,9 +3,21 @@ from aerosim_data import middleware
 
 import cv2
 import numpy as np
+import argparse
 from collections import deque
 from pathlib import Path
 from datetime import datetime
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser(description="Camera stream viewer with image capture")
+parser.add_argument(
+    "--transport",
+    type=str,
+    choices=["zenoh", "kafka"],
+    default="zenoh",
+    help="Middleware transport to use (default: zenoh)"
+)
+args = parser.parse_args()
 
 image_queue = deque(maxlen=1)
 serializer = middleware.BincodeSerializer()
@@ -32,12 +44,14 @@ def on_sensor_data(payload):
 
 
 # Set up middleware transport and subscribe to vehicle state
-transport = middleware.get_transport("zenoh")
+transport = middleware.get_transport(args.transport)
 transport.subscribe_raw(
     "aerosim::types::CompressedImage", "aerosim.renderer.responses", on_sensor_data
 )
 
-print(f"Camera stream viewer started. Images will be saved to: {output_dir.absolute()}")
+print(f"Camera stream viewer started")
+print(f"Transport: {args.transport}")
+print(f"Images will be saved to: {output_dir.absolute()}")
 print("Controls:")
 print("  's' - Save current frame")
 print("  ESC - Exit")

--- a/dev_scripts/camera_stream_opencv.py
+++ b/dev_scripts/camera_stream_opencv.py
@@ -15,7 +15,7 @@ parser.add_argument(
     type=str,
     choices=["zenoh", "kafka"],
     default="zenoh",
-    help="Middleware transport to use (default: zenoh)"
+    help="Middleware transport to use (default: zenoh)",
 )
 args = parser.parse_args()
 
@@ -28,13 +28,12 @@ cv2.namedWindow("Camera Preview")
 output_dir = Path("camera_captures")
 output_dir.mkdir(exist_ok=True)
 
-# Configuration for auto-saving
-AUTO_SAVE = False  # Set to False to only save on 's' keypress
+# Configuration for recording
+AUTO_SAVE = False  # Toggle with 's' key to start/stop recording
 save_counter = 0
 
 
 def on_sensor_data(payload):
-
     _, data = serializer.deserialize_message(aerosim_types.CompressedImage, payload)
 
     # Convert bytes to NumPy array
@@ -49,18 +48,26 @@ transport.subscribe_raw(
     "aerosim::types::CompressedImage", "aerosim.renderer.responses", on_sensor_data
 )
 
-print(f"Camera stream viewer started")
+print("Camera stream viewer started")
 print(f"Transport: {args.transport}")
 print(f"Images will be saved to: {output_dir.absolute()}")
 print("Controls:")
-print("  's' - Save current frame")
+print("  's' - Toggle recording on/off")
 print("  ESC - Exit")
-print(f"  AUTO_SAVE is {'ENABLED' if AUTO_SAVE else 'DISABLED'}")
+print(f"Recording: {'ON' if AUTO_SAVE else 'OFF'}")
 print()
 
 while True:
-    if image_queue:
+    # Check for key presses first
+    key = cv2.waitKey(20)
+    if key == 27:
+        break
+    elif key == ord("s"):
+        # Toggle recording on 's' keypress
+        AUTO_SAVE = not AUTO_SAVE
+        print(f"Recording: {'ON' if AUTO_SAVE else 'OFF'}")
 
+    if image_queue:
         image_rgb = image_queue.pop()
         cv2.imshow("Camera Preview", image_rgb)
 
@@ -70,17 +77,4 @@ while True:
             filename = output_dir / f"frame_{save_counter:05d}_{timestamp}.png"
             cv2.imwrite(str(filename), image_rgb)
             print(f"Saved: {filename.name}")
-            save_counter += 1
-
-    # Exit when pressing ESC
-    key = cv2.waitKey(20)
-    if key == 27:
-        break
-    elif key == ord('s'):
-        # Manual save on 's' keypress
-        if image_queue or 'image_rgb' in locals():
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-            filename = output_dir / f"manual_{save_counter:05d}_{timestamp}.png"
-            cv2.imwrite(str(filename), image_rgb)
-            print(f"Manually saved: {filename.name}")
             save_counter += 1

--- a/dev_scripts/camera_stream_opencv.py
+++ b/dev_scripts/camera_stream_opencv.py
@@ -4,11 +4,21 @@ from aerosim_data import middleware
 import cv2
 import numpy as np
 from collections import deque
+from pathlib import Path
+from datetime import datetime
 
 image_queue = deque(maxlen=1)
 serializer = middleware.BincodeSerializer()
 
 cv2.namedWindow("Camera Preview")
+
+# Setup output directory for saved images
+output_dir = Path("camera_captures")
+output_dir.mkdir(exist_ok=True)
+
+# Configuration for auto-saving
+AUTO_SAVE = False  # Set to False to only save on 's' keypress
+save_counter = 0
 
 
 def on_sensor_data(payload):
@@ -22,10 +32,17 @@ def on_sensor_data(payload):
 
 
 # Set up middleware transport and subscribe to vehicle state
-transport = middleware.get_transport("kafka")
+transport = middleware.get_transport("zenoh")
 transport.subscribe_raw(
     "aerosim::types::CompressedImage", "aerosim.renderer.responses", on_sensor_data
 )
+
+print(f"Camera stream viewer started. Images will be saved to: {output_dir.absolute()}")
+print("Controls:")
+print("  's' - Save current frame")
+print("  ESC - Exit")
+print(f"  AUTO_SAVE is {'ENABLED' if AUTO_SAVE else 'DISABLED'}")
+print()
 
 while True:
     if image_queue:
@@ -33,7 +50,23 @@ while True:
         image_rgb = image_queue.pop()
         cv2.imshow("Camera Preview", image_rgb)
 
+        # Auto-save if enabled
+        if AUTO_SAVE:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            filename = output_dir / f"frame_{save_counter:05d}_{timestamp}.png"
+            cv2.imwrite(str(filename), image_rgb)
+            print(f"Saved: {filename.name}")
+            save_counter += 1
+
     # Exit when pressing ESC
     key = cv2.waitKey(20)
     if key == 27:
         break
+    elif key == ord('s'):
+        # Manual save on 's' keypress
+        if image_queue or 'image_rgb' in locals():
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            filename = output_dir / f"manual_{save_counter:05d}_{timestamp}.png"
+            cv2.imwrite(str(filename), image_rgb)
+            print(f"Manually saved: {filename.name}")
+            save_counter += 1


### PR DESCRIPTION
## Summary

Fixes camera image corruption issue where horizontal black bands appeared in streamed images. The root cause was a race condition where image data was being compressed after GPU memory was unlocked, resulting in reading from invalid memory.

## Problem

Camera images received from the renderer's CameraSensor component showed horizontal bands of black corruption when viewed through `camera_stream_opencv.py`.

### Root Cause

The issue was a use-after-free bug in the image publishing pipeline:

1. GPU texture readback creates temporary memory mapping
2. FFI callback invoked with pointer to this memory
3. `publish_image_to_topic` **borrows** the pointer without copying (`Cow::Borrowed`)
4. Image queued to async channel with `try_send`
5. FFI call returns → GPU memory **unlocked and invalidated**
6. Later compression task reads from **invalid pointer** ⚠️

## Solution

Changed `aerosim-world-link/src/lib.rs:222` to copy image data before GPU memory unlock:

```diff
- data: Cow::Borrowed(image_data),
+ data: Cow::Owned(image_data.to_vec()),
```

This ensures the image data is copied into owned memory before the GPU readback buffer is released, preventing the async compression task from reading invalid memory.

Added inline documentation explaining why `Cow::Owned` is required and the consequences of using `Cow::Borrowed` (horizontal black bands from use-after-free).

## Additional Improvements

Enhanced `dev_scripts/camera_stream_opencv.py` with better debugging capabilities:

- **Parameterized transport**: Added `--transport` CLI argument to switch between zenoh (default) and kafka
- **Recording toggle**: Changed 's' key from single snapshot to continuous recording on/off toggle
- **Better UX**: Key handling moved before image processing to include current frame when starting recording
- **Code quality**: Applied ruff formatting, updated comments and terminology

### Usage

```bash
# Use default zenoh transport
python dev_scripts/camera_stream_opencv.py

# Use kafka transport
python dev_scripts/camera_stream_opencv.py --transport kafka

# Press 's' to toggle recording on/off
# Press ESC to exit
```

## Testing

- [x] Verified images saved to disk no longer show corruption
- [x] Tested with both zenoh and kafka transports
- [x] Confirmed recording toggle works correctly
- [x] All ruff linting checks pass

## Files Changed

- `aerosim-world-link/src/lib.rs` - Fixed race condition in image data handling + added explanatory comment
- `dev_scripts/camera_stream_opencv.py` - Enhanced with transport selection and recording toggle

## Commits

1. Fix camera image corruption by copying data before GPU memory unlock
2. Parameterize transport in camera_stream_opencv.py
3. Enhance camera_stream_opencv.py with recording toggle and transport selection
4. Add comment explaining Cow::Owned requirement in publish_image_to_topic
