### PR TITLE
Use actual image encoding for JPEG compression pixel format

### DIFF
--- a/aerosim-data/src/types/sensor.rs
+++ b/aerosim-data/src/types/sensor.rs
@@ -174,13 +174,19 @@ impl Image {
     }
 
     pub fn compress(&self) -> PyResult<CompressedImage> {
-        // FIXME: Currently hardcoded to BGRA as used in the renderer
+        let pixel_format = match self.encoding {
+            ImageEncoding::RGB8 => turbojpeg::PixelFormat::RGB,
+            ImageEncoding::RGBA8 => turbojpeg::PixelFormat::RGBA,
+            ImageEncoding::BGR8 => turbojpeg::PixelFormat::BGR,
+            ImageEncoding::BGRA8 => turbojpeg::PixelFormat::BGRA,
+            _ => turbojpeg::PixelFormat::BGRA, // fallback for non-RGB formats
+        };
         let raw_img = turbojpeg::Image {
             pixels: self.data.as_ref(),
             width: self.width as usize,
             pitch: self.step as usize,
             height: self.height as usize,
-            format: turbojpeg::PixelFormat::BGRA,
+            format: pixel_format,
         };
 
         let mut compressor = turbojpeg::Compressor::new().map_err(|e| {


### PR DESCRIPTION
## Summary
- `Image::compress()` was hardcoded to `turbojpeg::PixelFormat::BGRA`, causing R/B channel swap when compressing images with different encodings (e.g. RGBA from Isaac Sim renderer)
- Now uses the `Image.encoding` field to select the correct turbojpeg pixel format, supporting RGB8, RGBA8, BGR8, and BGRA8
- Falls back to BGRA for non-RGB formats (MONO8, MONO16, YUV422)

## Test plan
- [x] Run a sim with Isaac Sim renderer (RGBA8 images) and verify correct colors in `camera_stream_opencv.py`
- [x] Run a sim with Unreal renderer (BGRA8 images) and verify no color regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
