### PR TITLE
Add aerosim-isaac-sim paths to VS Code workspace

### DIFF
--- a/aerosim.code-workspace
+++ b/aerosim.code-workspace
@@ -26,6 +26,12 @@
 		},
 		{
 			"path": "../aerosim-simulink"
+		},
+		{
+			"path": "../aerosim-isaac-sim"
+		},
+		{
+			"path": "../aerosim-isaac-sim/source/extensions/aerosim.omniverse.extension"
 		}
 	],
 	"settings": {}


### PR DESCRIPTION
- Add `aerosim-isaac-sim` repository root and its Omniverse extension subdirectory to the VS Code multi-root workspace