### PR TITLE
Make PyO3 optional behind "python" feature flag in aerosim-data and aerosim-core

### DIFF
--- a/aerosim-core/Cargo.toml
+++ b/aerosim-core/Cargo.toml
@@ -14,12 +14,16 @@ crate-type = ["cdylib", "rlib"]
 aerosim-data = { path = "../aerosim-data", default-features = false }
 chrono.workspace = true
 log.workspace = true
-pyo3.workspace = true
+pyo3 = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 csv = "1.3.1"
 egm2008 = "0.1.0"
 quaternion-core = "0.5.3"
+
+[features]
+default = ["python"]
+python = ["pyo3", "aerosim-data/python"]
 
 [package.metadata.maturin]
 name = "aerosim.core"

--- a/aerosim-core/src/actor.rs
+++ b/aerosim-core/src/actor.rs
@@ -1,43 +1,29 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 use crate::math::rotator::Rotator;
 use aerosim_data::types::geometry::Vector3;
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub struct Actor {
-    #[pyo3(get, set)]
     uid: u64, // unique id identifier for this actor
-    #[pyo3(get, set)]
     actor_name: String, // actor name
-    #[pyo3(get, set)]
     actor_type: u64, // identifier for actor type
-    #[pyo3(get, set)]
     semantics: String, // Semantics of this actor
-    #[pyo3(get, set)]
     latitude: f64, // latitude for this actor // We maybe do not want this and we have to remove it, we will need to discuss how are we gonna manage internally poses
-    #[pyo3(get, set)]
     longitude: f64, // longitude for this actor // We maybe do not want this and we have to remove it, we will need to discuss how are we gonna manage internally poses
-    #[pyo3(get, set)]
     altitude: f64, // altitude for this actor // We maybe do not want this and we have to remove it, we will need to discuss how are we gonna manage internally poses
-    #[pyo3(get, set)]
     position: Vector3, // Position of this actor x y z meters from world origin
-    #[pyo3(get, set)]
     rotation: Rotator, // Rotation of this actor roll pitch yaw
-    #[pyo3(get, set)]
     velocity_linear: Vector3, // Velocity vector of this actor in m/s
-    #[pyo3(get, set)]
     velocity_angular: Vector3, // Velocity vector of this actor in rad/s
-    #[pyo3(get, set)]
     mass: f64,  // Mass of this actor in kg
-    #[pyo3(get, set)]
     parent_uid: u64,  // ID of the parent actor
 }
 
-#[pymethods]
 impl Actor {
-    #[new]
-    #[pyo3(signature = (actor_name, actor_type, semantics, latitude=0.0, longitude=0.0, altitude=0.0, position=Vector3{x: 0.0, y: 0.0, z: 0.0}, rotation=Rotator{yaw: 0.0, pitch: 0.0, roll: 0.0}, velocity=Vector3{x: 0.0, y: 0.0, z: 0.0}, velocity_angular=Vector3{x: 0.0, y: 0.0, z: 0.0}, mass=0.0, parent_uid=u64::MAX))]
     pub fn new(actor_name: String, actor_type: u64, semantics: String, latitude: f64, longitude: f64, altitude: f64, position: Vector3, rotation: Rotator, velocity: Vector3, velocity_angular:Vector3, mass: f64, parent_uid: u64) -> Self {
         let actor = Actor {
             uid: u64::MAX,
@@ -56,4 +42,79 @@ impl Actor {
         };
         return actor;
     }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Actor {
+    #[new]
+    #[pyo3(signature = (actor_name, actor_type, semantics, latitude=0.0, longitude=0.0, altitude=0.0, position=Vector3{x: 0.0, y: 0.0, z: 0.0}, rotation=Rotator{yaw: 0.0, pitch: 0.0, roll: 0.0}, velocity=Vector3{x: 0.0, y: 0.0, z: 0.0}, velocity_angular=Vector3{x: 0.0, y: 0.0, z: 0.0}, mass=0.0, parent_uid=u64::MAX))]
+    pub fn py_new(actor_name: String, actor_type: u64, semantics: String, latitude: f64, longitude: f64, altitude: f64, position: Vector3, rotation: Rotator, velocity: Vector3, velocity_angular:Vector3, mass: f64, parent_uid: u64) -> Self {
+        Self::new(actor_name, actor_type, semantics, latitude, longitude, altitude, position, rotation, velocity, velocity_angular, mass, parent_uid)
+    }
+
+    #[getter]
+    fn uid(&self) -> u64 { self.uid }
+    #[setter]
+    fn set_uid(&mut self, val: u64) { self.uid = val; }
+
+    #[getter]
+    fn actor_name(&self) -> String { self.actor_name.clone() }
+    #[setter]
+    fn set_actor_name(&mut self, val: String) { self.actor_name = val; }
+
+    #[getter]
+    fn actor_type(&self) -> u64 { self.actor_type }
+    #[setter]
+    fn set_actor_type(&mut self, val: u64) { self.actor_type = val; }
+
+    #[getter]
+    fn semantics(&self) -> String { self.semantics.clone() }
+    #[setter]
+    fn set_semantics(&mut self, val: String) { self.semantics = val; }
+
+    #[getter]
+    fn latitude(&self) -> f64 { self.latitude }
+    #[setter]
+    fn set_latitude(&mut self, val: f64) { self.latitude = val; }
+
+    #[getter]
+    fn longitude(&self) -> f64 { self.longitude }
+    #[setter]
+    fn set_longitude(&mut self, val: f64) { self.longitude = val; }
+
+    #[getter]
+    fn altitude(&self) -> f64 { self.altitude }
+    #[setter]
+    fn set_altitude(&mut self, val: f64) { self.altitude = val; }
+
+    #[getter]
+    fn position(&self) -> Vector3 { self.position }
+    #[setter]
+    fn set_position(&mut self, val: Vector3) { self.position = val; }
+
+    #[getter]
+    fn rotation(&self) -> Rotator { self.rotation }
+    #[setter]
+    fn set_rotation(&mut self, val: Rotator) { self.rotation = val; }
+
+    #[getter]
+    fn velocity_linear(&self) -> Vector3 { self.velocity_linear }
+    #[setter]
+    fn set_velocity_linear(&mut self, val: Vector3) { self.velocity_linear = val; }
+
+    #[getter]
+    fn velocity_angular(&self) -> Vector3 { self.velocity_angular }
+    #[setter]
+    fn set_velocity_angular(&mut self, val: Vector3) { self.velocity_angular = val; }
+
+    #[getter]
+    fn mass(&self) -> f64 { self.mass }
+    #[setter]
+    fn set_mass(&mut self, val: f64) { self.mass = val; }
+
+    #[getter]
+    fn parent_uid(&self) -> u64 { self.parent_uid }
+    #[setter]
+    fn set_parent_uid(&mut self, val: u64) { self.parent_uid = val; }
 }

--- a/aerosim-core/src/actor.rs
+++ b/aerosim-core/src/actor.rs
@@ -44,6 +44,8 @@ impl Actor {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl Actor {

--- a/aerosim-core/src/coordinate_system/conversion_utils.rs
+++ b/aerosim-core/src/coordinate_system/conversion_utils.rs
@@ -1,4 +1,5 @@
 use crate::coordinate_system::geo::{Ellipsoid, Geoid, OffsetMap};
+
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 

--- a/aerosim-core/src/coordinate_system/conversion_utils.rs
+++ b/aerosim-core/src/coordinate_system/conversion_utils.rs
@@ -1,4 +1,5 @@
 use crate::coordinate_system::geo::{Ellipsoid, Geoid, OffsetMap};
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 // -------------------------------------------------------------------------------
@@ -55,8 +56,8 @@ pub fn rpy_nwu_to_enu(roll: f64, pitch: f64, yaw: f64) -> (f64, f64, f64) {
 // -------------------------------------------------------------------------------
 // Geocoordinate System Conversions
 
-#[pyfunction]
-#[pyo3(signature = (lat, lon, alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (lat, lon, alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn lla_to_ecef(lat: f64, lon: f64, alt: f64, ellipsoid: Ellipsoid) -> (f64, f64, f64) {
     let cos_lat = lat.to_radians().cos();
     let sin_lat = lat.to_radians().sin();
@@ -74,8 +75,8 @@ pub fn lla_to_ecef(lat: f64, lon: f64, alt: f64, ellipsoid: Ellipsoid) -> (f64, 
     (x, y, z)
 }
 
-#[pyfunction]
-#[pyo3(signature = (ecef_x, ecef_y, ecef_z, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (ecef_x, ecef_y, ecef_z, ellipsoid=Ellipsoid::wgs84())))]
 pub fn ecef_to_lla(ecef_x: f64, ecef_y: f64, ecef_z: f64, ellipsoid: Ellipsoid) -> (f64, f64, f64) {
     let e2 = (ellipsoid.equatorial_radius.powi(2) - ellipsoid.polar_radius.powi(2))
         / ellipsoid.equatorial_radius.powi(2);
@@ -98,8 +99,8 @@ pub fn ecef_to_lla(ecef_x: f64, ecef_y: f64, ecef_z: f64, ellipsoid: Ellipsoid) 
     (lat, lon, alt)
 }
 
-#[pyfunction]
-#[pyo3(signature = (north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn ned_to_ecef(
     north: f64,
     east: f64,
@@ -124,8 +125,8 @@ pub fn ned_to_ecef(
     (origin_ecef_x + dx, origin_ecef_y + dy, origin_ecef_z + dz)
 }
 
-#[pyfunction]
-#[pyo3(signature = (ecef_x, ecef_y, ecef_z, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (ecef_x, ecef_y, ecef_z, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn ecef_to_ned(
     ecef_x: f64,
     ecef_y: f64,
@@ -155,8 +156,8 @@ pub fn ecef_to_ned(
     (north, east, down)
 }
 
-#[pyfunction]
-#[pyo3(signature = (lat, lon, alt, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (lat, lon, alt, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn lla_to_ned(
     lat: f64,
     lon: f64,
@@ -172,8 +173,8 @@ pub fn lla_to_ned(
     )
 }
 
-#[pyfunction]
-#[pyo3(signature = (north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn ned_to_lla(
     north: f64,
     east: f64,
@@ -189,8 +190,8 @@ pub fn ned_to_lla(
     ecef_to_lla(ecef_x, ecef_y, ecef_z, ellipsoid)
 }
 
-#[pyfunction]
-#[pyo3(signature = (lat, lon, alt, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (lat, lon, alt, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn lla_to_cartesian(
     lat: f64,
     lon: f64,
@@ -210,8 +211,8 @@ pub fn lla_to_cartesian(
     (cartesian_x, cartesian_y, cartesian_z)
 }
 
-#[pyfunction]
-#[pyo3(signature = (north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn ned_to_cartesian(
     north: f64,
     east: f64,
@@ -233,8 +234,8 @@ pub fn ned_to_cartesian(
     (cartesian_x, cartesian_y, cartesian_z)
 }
 
-#[pyfunction]
-#[pyo3(signature = (point_x, point_y, point_z, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (point_x, point_y, point_z, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn cartesian_to_ned(
     point_x: f64,
     point_y: f64,
@@ -252,8 +253,8 @@ pub fn cartesian_to_ned(
     )
 }
 
-#[pyfunction]
-#[pyo3(signature = (point_x, point_y, point_z, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84()))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (point_x, point_y, point_z, origin_lat, origin_lon, origin_alt, ellipsoid=Ellipsoid::wgs84())))]
 pub fn cartesian_to_lla(
     point_x: f64,
     point_y: f64,
@@ -269,8 +270,8 @@ pub fn cartesian_to_lla(
     ecef_to_lla(ecef_x, ecef_y, ecef_z, ellipsoid)
 }
 
-#[pyfunction]
-#[pyo3(signature = (lat, lon, alt, geoid))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (lat, lon, alt, geoid)))]
 pub fn msl_to_hae(lat: f64, lon: f64, alt: f64, geoid: &Geoid) -> f64 {
     let geoid_height = geoid.get_geoid_height(lat, lon);
 
@@ -278,8 +279,8 @@ pub fn msl_to_hae(lat: f64, lon: f64, alt: f64, geoid: &Geoid) -> f64 {
     hae_altitude
 }
 
-#[pyfunction]
-#[pyo3(signature = (lat, lon, alt, geoid))]
+#[cfg_attr(feature = "python", pyfunction)]
+#[cfg_attr(feature = "python", pyo3(signature = (lat, lon, alt, geoid)))]
 pub fn hae_to_msl(lat: f64, lon: f64, alt: f64, geoid: &Geoid) -> f64 {
     let geoid_height = geoid.get_geoid_height(lat, lon);
 
@@ -287,7 +288,7 @@ pub fn hae_to_msl(lat: f64, lon: f64, alt: f64, geoid: &Geoid) -> f64 {
     msl_altitude
 }
 
-#[pyfunction]
+#[cfg_attr(feature = "python", pyfunction)]
 pub fn msl_to_hae_with_offset(
     lat: f64,
     lon: f64,
@@ -302,7 +303,7 @@ pub fn msl_to_hae_with_offset(
     hae_altitude
 }
 
-#[pyfunction]
+#[cfg_attr(feature = "python", pyfunction)]
 pub fn hae_to_msl_with_offset(
     lat: f64,
     lon: f64,

--- a/aerosim-core/src/coordinate_system/geo.rs
+++ b/aerosim-core/src/coordinate_system/geo.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use std::fs::File;
 use std::io::Read;
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Ellipsoid {
     pub equatorial_radius: f64,
@@ -12,9 +13,7 @@ pub struct Ellipsoid {
     pub polar_radius: f64,
 }
 
-#[pymethods]
 impl Ellipsoid {
-    #[staticmethod]
     pub fn wgs84() -> Self {
         let equatorial_radius = 6378137.0;
         let flattening_factor = 1.0 / 298.257223563;
@@ -26,8 +25,6 @@ impl Ellipsoid {
         }
     }
 
-    #[staticmethod]
-    #[pyo3(signature = (equatorial_radius = 0.0, flattening_factor = 0.0))]
     pub fn custom(equatorial_radius: f64, flattening_factor: f64) -> Self {
         let polar_radius = equatorial_radius * (1.0 - flattening_factor);
         Self {
@@ -38,11 +35,28 @@ impl Ellipsoid {
     }
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
+impl Ellipsoid {
+    #[staticmethod]
+    #[pyo3(name = "wgs84")]
+    pub fn py_wgs84() -> Self {
+        Self::wgs84()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "custom")]
+    #[pyo3(signature = (equatorial_radius = 0.0, flattening_factor = 0.0))]
+    pub fn py_custom(equatorial_radius: f64, flattening_factor: f64) -> Self {
+        Self::custom(equatorial_radius, flattening_factor)
+    }
+}
+
 pub trait GeoidModel: Send + Sync {
     fn geoid_height(&self, lat: f64, lon: f64) -> f64;
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Copy, Clone, Debug)]
 pub struct EGM08;
 
@@ -57,14 +71,12 @@ impl GeoidModel for EGM08 {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct Geoid {
     model: Box<dyn GeoidModel>,
 }
 
-#[pymethods]
 impl Geoid {
-    #[staticmethod]
     pub fn egm08() -> Self {
         Self {
             model: Box::new(EGM08),
@@ -77,7 +89,22 @@ impl Geoid {
     }
 }
 
-#[pyclass]
+#[cfg(feature = "python")]
+#[pymethods]
+impl Geoid {
+    #[staticmethod]
+    #[pyo3(name = "egm08")]
+    pub fn py_egm08() -> Self {
+        Self::egm08()
+    }
+
+    #[pyo3(name = "get_geoid_height")]
+    pub fn py_get_geoid_height(&self, lat: f64, lon: f64) -> f64 {
+        self.get_geoid_height(lat, lon)
+    }
+}
+
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct GeodeticBounds {
     pub lat_min: f64,
@@ -86,9 +113,7 @@ pub struct GeodeticBounds {
     pub lon_max: f64,
 }
 
-#[pymethods]
 impl GeodeticBounds {
-    #[new]
     pub fn new(lat_min: f64, lat_max: f64, lon_min: f64, lon_max: f64) -> Self {
         GeodeticBounds {
             lat_min,
@@ -99,7 +124,16 @@ impl GeodeticBounds {
     }
 }
 
-#[pyclass]
+#[cfg(feature = "python")]
+#[pymethods]
+impl GeodeticBounds {
+    #[new]
+    pub fn py_new(lat_min: f64, lat_max: f64, lon_min: f64, lon_max: f64) -> Self {
+        Self::new(lat_min, lat_max, lon_min, lon_max)
+    }
+}
+
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct OffsetMap {
     pub bounds: GeodeticBounds,
@@ -108,9 +142,7 @@ pub struct OffsetMap {
     pub offsets: Vec<f64>,
 }
 
-#[pymethods]
 impl OffsetMap {
-    #[new]
     pub fn new(
         bounds: GeodeticBounds,
         lat_resolution: usize,
@@ -127,7 +159,6 @@ impl OffsetMap {
         }
     }
 
-    #[staticmethod]
     pub fn from_json(file_path: &str) -> Self {
         let mut file = File::open(file_path).expect("Unable to open file");
         let mut data = String::new();
@@ -225,14 +256,38 @@ impl OffsetMap {
     }
 }
 
-#[pyfunction]
+#[cfg(feature = "python")]
+#[pymethods]
+impl OffsetMap {
+    #[new]
+    pub fn py_new(
+        bounds: GeodeticBounds,
+        lat_resolution: usize,
+        lon_resolution: usize,
+        offsets: Vec<f64>,
+    ) -> Self {
+        Self::new(bounds, lat_resolution, lon_resolution, offsets)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_json")]
+    pub fn py_from_json(file_path: &str) -> Self {
+        Self::from_json(file_path)
+    }
+
+    #[pyo3(name = "get_offset")]
+    pub fn py_get_offset(&self, lat: f64, lon: f64) -> f64 {
+        self.get_offset(lat, lon)
+    }
+}
+
 // Haversine distance in meters from (lat1, lon1) to (lat2, lon2)
 pub fn haversine_distance_meters(
     lat1_deg: f64,
     lon1_deg: f64,
     lat2_deg: f64,
     lon2_deg: f64,
-) -> PyResult<f64> {
+) -> f64 {
     let r = 6371.0; // Earth radius in km
     let d_lat = (lat2_deg - lat1_deg).to_radians();
     let d_lon = (lon2_deg - lon1_deg).to_radians();
@@ -242,12 +297,11 @@ pub fn haversine_distance_meters(
             * (d_lon / 2.0).sin()
             * (d_lon / 2.0).sin();
     let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
-    Ok(r * c * 1000.0) // return distance in meters
+    r * c * 1000.0 // return distance in meters
 }
 
 // Bearing angle in degrees (0-360) for line from (lat1, lon1) to (lat2, lon2)
-#[pyfunction]
-pub fn bearing_deg(lat1_deg: f64, lon1_deg: f64, lat2_deg: f64, lon2_deg: f64) -> PyResult<f64> {
+pub fn bearing_deg(lat1_deg: f64, lon1_deg: f64, lat2_deg: f64, lon2_deg: f64) -> f64 {
     let lat1_rad = lat1_deg.to_radians();
     let lat2_rad = lat2_deg.to_radians();
     let delta_lon = (lon2_deg - lon1_deg).to_radians();
@@ -255,13 +309,12 @@ pub fn bearing_deg(lat1_deg: f64, lon1_deg: f64, lat2_deg: f64, lon2_deg: f64) -
     let x = lat1_rad.cos() * lat2_rad.sin() - lat1_rad.sin() * lat2_rad.cos() * delta_lon.cos();
     let bearing_rad = y.atan2(x);
     let bearing_deg = (bearing_rad.to_degrees() + 360.0) % 360.0;
-    Ok(bearing_deg)
+    bearing_deg
 }
 
 // Approximation of the perpindicular deviation distance from course in meters.
 // Calculated from the right angle triangle formed between course line and line from
 // course start to position.
-#[pyfunction]
 pub fn deviation_from_course_meters(
     course_lat1_deg: f64,
     course_lon1_deg: f64,
@@ -269,16 +322,16 @@ pub fn deviation_from_course_meters(
     course_lon2_deg: f64,
     pos_lat_deg: f64,
     pos_lon_deg: f64,
-) -> PyResult<f64> {
+) -> f64 {
     let course_bearing = bearing_deg(
         course_lat1_deg,
         course_lon1_deg,
         course_lat2_deg,
         course_lon2_deg,
-    )?;
-    let pos_bearing = bearing_deg(course_lat1_deg, course_lon1_deg, pos_lat_deg, pos_lon_deg)?;
+    );
+    let pos_bearing = bearing_deg(course_lat1_deg, course_lon1_deg, pos_lat_deg, pos_lon_deg);
     let dist_to_course_pt1 =
-        haversine_distance_meters(course_lat1_deg, course_lon1_deg, pos_lat_deg, pos_lon_deg)?;
+        haversine_distance_meters(course_lat1_deg, course_lon1_deg, pos_lat_deg, pos_lon_deg);
     let mut angle_diff = (pos_bearing - course_bearing) % 360.0;
     if angle_diff > 180.0 {
         angle_diff -= 360.0;
@@ -287,5 +340,45 @@ pub fn deviation_from_course_meters(
     // distance from course start point to position and theta as the difference in
     // bearings between course and the line from course start to position.
     let deviation = dist_to_course_pt1 * angle_diff.to_radians().sin();
-    Ok(deviation)
+    deviation
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "haversine_distance_meters")]
+pub fn py_haversine_distance_meters(
+    lat1_deg: f64,
+    lon1_deg: f64,
+    lat2_deg: f64,
+    lon2_deg: f64,
+) -> PyResult<f64> {
+    Ok(haversine_distance_meters(lat1_deg, lon1_deg, lat2_deg, lon2_deg))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "bearing_deg")]
+pub fn py_bearing_deg(lat1_deg: f64, lon1_deg: f64, lat2_deg: f64, lon2_deg: f64) -> PyResult<f64> {
+    Ok(bearing_deg(lat1_deg, lon1_deg, lat2_deg, lon2_deg))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "deviation_from_course_meters")]
+pub fn py_deviation_from_course_meters(
+    course_lat1_deg: f64,
+    course_lon1_deg: f64,
+    course_lat2_deg: f64,
+    course_lon2_deg: f64,
+    pos_lat_deg: f64,
+    pos_lon_deg: f64,
+) -> PyResult<f64> {
+    Ok(deviation_from_course_meters(
+        course_lat1_deg,
+        course_lon1_deg,
+        course_lat2_deg,
+        course_lon2_deg,
+        pos_lat_deg,
+        pos_lon_deg,
+    ))
 }

--- a/aerosim-core/src/coordinate_system/geo.rs
+++ b/aerosim-core/src/coordinate_system/geo.rs
@@ -35,23 +35,6 @@ impl Ellipsoid {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl Ellipsoid {
-    #[staticmethod]
-    #[pyo3(name = "wgs84")]
-    pub fn py_wgs84() -> Self {
-        Self::wgs84()
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "custom")]
-    #[pyo3(signature = (equatorial_radius = 0.0, flattening_factor = 0.0))]
-    pub fn py_custom(equatorial_radius: f64, flattening_factor: f64) -> Self {
-        Self::custom(equatorial_radius, flattening_factor)
-    }
-}
-
 pub trait GeoidModel: Send + Sync {
     fn geoid_height(&self, lat: f64, lon: f64) -> f64;
 }
@@ -89,21 +72,6 @@ impl Geoid {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl Geoid {
-    #[staticmethod]
-    #[pyo3(name = "egm08")]
-    pub fn py_egm08() -> Self {
-        Self::egm08()
-    }
-
-    #[pyo3(name = "get_geoid_height")]
-    pub fn py_get_geoid_height(&self, lat: f64, lon: f64) -> f64 {
-        self.get_geoid_height(lat, lon)
-    }
-}
-
 #[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct GeodeticBounds {
@@ -121,15 +89,6 @@ impl GeodeticBounds {
             lon_min,
             lon_max,
         }
-    }
-}
-
-#[cfg(feature = "python")]
-#[pymethods]
-impl GeodeticBounds {
-    #[new]
-    pub fn py_new(lat_min: f64, lat_max: f64, lon_min: f64, lon_max: f64) -> Self {
-        Self::new(lat_min, lat_max, lon_min, lon_max)
     }
 }
 
@@ -256,31 +215,6 @@ impl OffsetMap {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl OffsetMap {
-    #[new]
-    pub fn py_new(
-        bounds: GeodeticBounds,
-        lat_resolution: usize,
-        lon_resolution: usize,
-        offsets: Vec<f64>,
-    ) -> Self {
-        Self::new(bounds, lat_resolution, lon_resolution, offsets)
-    }
-
-    #[staticmethod]
-    #[pyo3(name = "from_json")]
-    pub fn py_from_json(file_path: &str) -> Self {
-        Self::from_json(file_path)
-    }
-
-    #[pyo3(name = "get_offset")]
-    pub fn py_get_offset(&self, lat: f64, lon: f64) -> f64 {
-        self.get_offset(lat, lon)
-    }
-}
-
 // Haversine distance in meters from (lat1, lon1) to (lat2, lon2)
 pub fn haversine_distance_meters(
     lat1_deg: f64,
@@ -341,6 +275,74 @@ pub fn deviation_from_course_meters(
     // bearings between course and the line from course start to position.
     let deviation = dist_to_course_pt1 * angle_diff.to_radians().sin();
     deviation
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Ellipsoid {
+    #[staticmethod]
+    #[pyo3(name = "wgs84")]
+    pub fn py_wgs84() -> Self {
+        Self::wgs84()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "custom")]
+    #[pyo3(signature = (equatorial_radius = 0.0, flattening_factor = 0.0))]
+    pub fn py_custom(equatorial_radius: f64, flattening_factor: f64) -> Self {
+        Self::custom(equatorial_radius, flattening_factor)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Geoid {
+    #[staticmethod]
+    #[pyo3(name = "egm08")]
+    pub fn py_egm08() -> Self {
+        Self::egm08()
+    }
+
+    #[pyo3(name = "get_geoid_height")]
+    pub fn py_get_geoid_height(&self, lat: f64, lon: f64) -> f64 {
+        self.get_geoid_height(lat, lon)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl GeodeticBounds {
+    #[new]
+    pub fn py_new(lat_min: f64, lat_max: f64, lon_min: f64, lon_max: f64) -> Self {
+        Self::new(lat_min, lat_max, lon_min, lon_max)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl OffsetMap {
+    #[new]
+    pub fn py_new(
+        bounds: GeodeticBounds,
+        lat_resolution: usize,
+        lon_resolution: usize,
+        offsets: Vec<f64>,
+    ) -> Self {
+        Self::new(bounds, lat_resolution, lon_resolution, offsets)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_json")]
+    pub fn py_from_json(file_path: &str) -> Self {
+        Self::from_json(file_path)
+    }
+
+    #[pyo3(name = "get_offset")]
+    pub fn py_get_offset(&self, lat: f64, lon: f64) -> f64 {
+        self.get_offset(lat, lon)
+    }
 }
 
 #[cfg(feature = "python")]

--- a/aerosim-core/src/coordinate_system/world_coordinate.rs
+++ b/aerosim-core/src/coordinate_system/world_coordinate.rs
@@ -237,6 +237,8 @@ impl WorldCoordinate {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl WorldCoordinate {

--- a/aerosim-core/src/coordinate_system/world_coordinate.rs
+++ b/aerosim-core/src/coordinate_system/world_coordinate.rs
@@ -1,7 +1,8 @@
 use crate::{coordinate_system::conversion_utils::*, Ellipsoid};
+use serde::{Deserialize, Serialize};
+
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
-use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "python", pyclass)]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/aerosim-core/src/coordinate_system/world_coordinate.rs
+++ b/aerosim-core/src/coordinate_system/world_coordinate.rs
@@ -1,8 +1,9 @@
 use crate::{coordinate_system::conversion_utils::*, Ellipsoid};
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct WorldCoordinate {
     // TODO Temporarily set variables as pub access for scene graph development. Change
@@ -19,10 +20,7 @@ pub struct WorldCoordinate {
 // TODO - Change cartesian axes to x=N y=E z=D at origin
 // TODO - Add methdos to convert cartesian-ECEF
 // TODO - Check accuracy of conversions and fix if necessary (especially NED-LLA)
-#[pymethods]
 impl WorldCoordinate {
-    #[new]
-    #[pyo3(signature = (origin_lat=0.0, origin_lon=0.0, origin_alt=0.0, ellipsoid=Ellipsoid::wgs84()))]
     pub fn new(origin_lat: f64, origin_lon: f64, origin_alt: f64, ellipsoid: Ellipsoid) -> Self {
         let ned = (0.0, 0.0, 0.0);
         WorldCoordinate {
@@ -41,7 +39,6 @@ impl WorldCoordinate {
         }
     }
 
-    #[staticmethod]
     pub fn from_ned(
         north: f64,
         east: f64,
@@ -57,7 +54,6 @@ impl WorldCoordinate {
         sim_coordinate
     }
 
-    #[staticmethod]
     pub fn from_lla(
         lat: f64,
         lon: f64,
@@ -73,7 +69,6 @@ impl WorldCoordinate {
         sim_coordinate
     }
 
-    #[staticmethod]
     pub fn from_ecef(
         x: f64,
         y: f64,
@@ -89,7 +84,6 @@ impl WorldCoordinate {
         sim_coordinate
     }
 
-    #[staticmethod]
     pub fn from_cartesian(
         x: f64,
         y: f64,
@@ -239,5 +233,111 @@ impl WorldCoordinate {
 
     pub fn cartesian(&self) -> (f64, f64, f64) {
         self.cartesian
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl WorldCoordinate {
+    #[new]
+    #[pyo3(signature = (origin_lat=0.0, origin_lon=0.0, origin_alt=0.0, ellipsoid=Ellipsoid::wgs84()))]
+    pub fn py_new(origin_lat: f64, origin_lon: f64, origin_alt: f64, ellipsoid: Ellipsoid) -> Self {
+        Self::new(origin_lat, origin_lon, origin_alt, ellipsoid)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_ned")]
+    pub fn py_from_ned(
+        north: f64,
+        east: f64,
+        down: f64,
+        origin_lat: f64,
+        origin_lon: f64,
+        origin_alt: f64,
+        ellipsoid: Ellipsoid,
+    ) -> Self {
+        Self::from_ned(north, east, down, origin_lat, origin_lon, origin_alt, ellipsoid)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_lla")]
+    pub fn py_from_lla(
+        lat: f64,
+        lon: f64,
+        alt: f64,
+        origin_lat: f64,
+        origin_lon: f64,
+        origin_alt: f64,
+        ellipsoid: Ellipsoid,
+    ) -> Self {
+        Self::from_lla(lat, lon, alt, origin_lat, origin_lon, origin_alt, ellipsoid)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_ecef")]
+    pub fn py_from_ecef(
+        x: f64,
+        y: f64,
+        z: f64,
+        origin_lat: f64,
+        origin_lon: f64,
+        origin_alt: f64,
+        ellipsoid: Ellipsoid,
+    ) -> Self {
+        Self::from_ecef(x, y, z, origin_lat, origin_lon, origin_alt, ellipsoid)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_cartesian")]
+    pub fn py_from_cartesian(
+        x: f64,
+        y: f64,
+        z: f64,
+        origin_lat: f64,
+        origin_lon: f64,
+        origin_alt: f64,
+        ellipsoid: Ellipsoid,
+    ) -> Self {
+        Self::from_cartesian(x, y, z, origin_lat, origin_lon, origin_alt, ellipsoid)
+    }
+
+    #[pyo3(name = "set_ned")]
+    pub fn py_set_ned(&mut self, north: f64, east: f64, down: f64) {
+        self.set_ned(north, east, down)
+    }
+
+    #[pyo3(name = "ned")]
+    pub fn py_ned(&self) -> (f64, f64, f64) {
+        self.ned()
+    }
+
+    #[pyo3(name = "set_lla")]
+    pub fn py_set_lla(&mut self, lat: f64, lon: f64, alt: f64) {
+        self.set_lla(lat, lon, alt)
+    }
+
+    #[pyo3(name = "lla")]
+    pub fn py_lla(&self) -> (f64, f64, f64) {
+        self.lla()
+    }
+
+    #[pyo3(name = "set_ecef")]
+    pub fn py_set_ecef(&mut self, x: f64, y: f64, z: f64) {
+        self.set_ecef(x, y, z)
+    }
+
+    #[pyo3(name = "ecef")]
+    pub fn py_ecef(&self) -> (f64, f64, f64) {
+        self.ecef()
+    }
+
+    #[pyo3(name = "set_cartesian")]
+    pub fn py_set_cartesian(&mut self, x: f64, y: f64, z: f64) {
+        self.set_cartesian(x, y, z)
+    }
+
+    #[pyo3(name = "cartesian")]
+    pub fn py_cartesian(&self) -> (f64, f64, f64) {
+        self.cartesian()
     }
 }

--- a/aerosim-core/src/lib.rs
+++ b/aerosim-core/src/lib.rs
@@ -1,27 +1,32 @@
-use pyo3::prelude::*;
 // use pyo3::wrap_pyfunction;
 
 // -------------------------------------------------------------------------
 // Aerosimcore classes
 
 pub mod actor;
-use crate::actor::Actor;
 
 pub mod math;
-use crate::math::rotator::Rotator;
 
 pub mod coordinate_system;
 use crate::coordinate_system::conversion_utils::*;
 use crate::coordinate_system::geo::*;
-use crate::coordinate_system::world_coordinate::*;
 
 pub mod trajectory;
 
 pub mod path;
 
+#[cfg(feature = "python")]
+use {
+    pyo3::prelude::*,
+    crate::actor::Actor,
+    crate::math::rotator::Rotator,
+    crate::coordinate_system::world_coordinate::*,
+};
+
 // -------------------------------------------------------------------------
 // Python module exports
 
+#[cfg(feature = "python")]
 #[pymodule]
 fn _aerocore(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Actor>()?;
@@ -40,18 +45,18 @@ fn _aerocore(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cartesian_to_ned, m)?)?;
     m.add_function(wrap_pyfunction!(msl_to_hae, m)?)?;
     m.add_function(wrap_pyfunction!(hae_to_msl, m)?)?;
-    m.add_function(wrap_pyfunction!(trajectory::generate_trajectory, m)?)?;
-    m.add_function(wrap_pyfunction!(trajectory::generate_trajectory_linear, m)?)?;
+    m.add_function(wrap_pyfunction!(trajectory::py_generate_trajectory, m)?)?;
+    m.add_function(wrap_pyfunction!(trajectory::py_generate_trajectory_linear, m)?)?;
     m.add_function(wrap_pyfunction!(
-        trajectory::generate_trajectory_from_adsb_csv,
+        trajectory::py_generate_trajectory_from_adsb_csv,
         m
     )?)?;
     m.add_function(wrap_pyfunction!(msl_to_hae_with_offset, m)?)?;
     m.add_function(wrap_pyfunction!(hae_to_msl_with_offset, m)?)?;
-    m.add_function(wrap_pyfunction!(haversine_distance_meters, m)?)?;
-    m.add_function(wrap_pyfunction!(bearing_deg, m)?)?;
-    m.add_function(wrap_pyfunction!(deviation_from_course_meters, m)?)?;
+    m.add_function(wrap_pyfunction!(py_haversine_distance_meters, m)?)?;
+    m.add_function(wrap_pyfunction!(py_bearing_deg, m)?)?;
+    m.add_function(wrap_pyfunction!(py_deviation_from_course_meters, m)?)?;
 
-    m.add_function(wrap_pyfunction!(path::read_config_file, m)?)?;
+    m.add_function(wrap_pyfunction!(path::py_read_config_file, m)?)?;
     Ok(())
 }

--- a/aerosim-core/src/math/rotator.rs
+++ b/aerosim-core/src/math/rotator.rs
@@ -1,14 +1,12 @@
 use std::ops;
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
-#[pyclass(subclass)]
+#[cfg_attr(feature = "python", pyclass(subclass))]
 #[derive(Clone, Copy, Debug)]
 pub struct Rotator {
-    #[pyo3(get, set)]
     pub roll: f64,
-    #[pyo3(get, set)]
     pub pitch: f64,
-    #[pyo3(get, set)]
     pub yaw: f64,
 }
 
@@ -18,16 +16,42 @@ impl Default for Rotator {
     }
 }
 
-#[pymethods]
 impl Rotator {
-    #[new]
-    #[pyo3(signature = (roll = 0.0, pitch = 0.0, yaw = 0.0))]
     pub fn new(roll: f64, pitch: f64, yaw: f64) -> Self {
         Self { roll, pitch, yaw }
     }
 
-    pub const fn to_python_tuple(&self) -> (f64, f64, f64) {
+    pub const fn to_tuple(&self) -> (f64, f64, f64) {
         (self.roll, self.pitch, self.yaw)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Rotator {
+    #[new]
+    #[pyo3(signature = (roll = 0.0, pitch = 0.0, yaw = 0.0))]
+    pub fn py_new(roll: f64, pitch: f64, yaw: f64) -> Self {
+        Self::new(roll, pitch, yaw)
+    }
+
+    #[getter]
+    fn roll(&self) -> f64 { self.roll }
+    #[setter]
+    fn set_roll(&mut self, val: f64) { self.roll = val; }
+
+    #[getter]
+    fn pitch(&self) -> f64 { self.pitch }
+    #[setter]
+    fn set_pitch(&mut self, val: f64) { self.pitch = val; }
+
+    #[getter]
+    fn yaw(&self) -> f64 { self.yaw }
+    #[setter]
+    fn set_yaw(&mut self, val: f64) { self.yaw = val; }
+
+    pub const fn to_python_tuple(&self) -> (f64, f64, f64) {
+        self.to_tuple()
     }
 }
 
@@ -159,9 +183,9 @@ mod tests {
     }
 
     #[test]
-    fn test_to_python_tuple() {
+    fn test_to_tuple() {
         let rotator = Rotator::new(1.0, 2.0, 3.0);
-        let result = rotator.to_python_tuple();
+        let result = rotator.to_tuple();
         assert_eq!(result, (1.0, 2.0, 3.0));
     }
 

--- a/aerosim-core/src/math/rotator.rs
+++ b/aerosim-core/src/math/rotator.rs
@@ -27,35 +27,6 @@ impl Rotator {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl Rotator {
-    #[new]
-    #[pyo3(signature = (roll = 0.0, pitch = 0.0, yaw = 0.0))]
-    pub fn py_new(roll: f64, pitch: f64, yaw: f64) -> Self {
-        Self::new(roll, pitch, yaw)
-    }
-
-    #[getter]
-    fn roll(&self) -> f64 { self.roll }
-    #[setter]
-    fn set_roll(&mut self, val: f64) { self.roll = val; }
-
-    #[getter]
-    fn pitch(&self) -> f64 { self.pitch }
-    #[setter]
-    fn set_pitch(&mut self, val: f64) { self.pitch = val; }
-
-    #[getter]
-    fn yaw(&self) -> f64 { self.yaw }
-    #[setter]
-    fn set_yaw(&mut self, val: f64) { self.yaw = val; }
-
-    pub const fn to_python_tuple(&self) -> (f64, f64, f64) {
-        self.to_tuple()
-    }
-}
-
 impl ops::Add<Rotator> for Rotator {
     type Output = Rotator;
 
@@ -120,6 +91,36 @@ impl ops::Mul<Rotator> for f64 {
     }
 }
 
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Rotator {
+    #[new]
+    #[pyo3(signature = (roll = 0.0, pitch = 0.0, yaw = 0.0))]
+    pub fn py_new(roll: f64, pitch: f64, yaw: f64) -> Self {
+        Self::new(roll, pitch, yaw)
+    }
+
+    #[getter]
+    fn roll(&self) -> f64 { self.roll }
+    #[setter]
+    fn set_roll(&mut self, val: f64) { self.roll = val; }
+
+    #[getter]
+    fn pitch(&self) -> f64 { self.pitch }
+    #[setter]
+    fn set_pitch(&mut self, val: f64) { self.pitch = val; }
+
+    #[getter]
+    fn yaw(&self) -> f64 { self.yaw }
+    #[setter]
+    fn set_yaw(&mut self, val: f64) { self.yaw = val; }
+
+    pub const fn to_python_tuple(&self) -> (f64, f64, f64) {
+        self.to_tuple()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/aerosim-core/src/math/rotator.rs
+++ b/aerosim-core/src/math/rotator.rs
@@ -1,4 +1,5 @@
 use std::ops;
+
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 

--- a/aerosim-core/src/path.rs
+++ b/aerosim-core/src/path.rs
@@ -34,6 +34,8 @@ pub fn read_config_file(file_name: &str) -> io::Result<String> {
     Ok(content)
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(name = "read_config_file")]

--- a/aerosim-core/src/path.rs
+++ b/aerosim-core/src/path.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 use std::env;
@@ -5,7 +6,7 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
 
-pub fn read_config_file_internal(file_name: &str) -> io::Result<String> {
+pub fn read_config_file(file_name: &str) -> io::Result<String> {
     // Get the current working directory (usually the root of the project)
     let binding = env::current_dir().expect("Failed to get current directory");
     let current_dir = binding.to_str().unwrap();
@@ -33,9 +34,11 @@ pub fn read_config_file_internal(file_name: &str) -> io::Result<String> {
     Ok(content)
 }
 
+#[cfg(feature = "python")]
 #[pyfunction]
-pub fn read_config_file(file_name: &str) -> PyResult<String> {
-    match read_config_file_internal(file_name) {
+#[pyo3(name = "read_config_file")]
+pub fn py_read_config_file(file_name: &str) -> PyResult<String> {
+    match read_config_file(file_name) {
         Ok(content) => Ok(content),
         Err(e) => Err(pyo3::exceptions::PyIOError::new_err(e.to_string())),
     }

--- a/aerosim-core/src/trajectory.rs
+++ b/aerosim-core/src/trajectory.rs
@@ -846,6 +846,8 @@ pub fn generate_trajectory_from_adsb_csv(
     Ok(())
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(name = "generate_trajectory", signature = (

--- a/aerosim-core/src/trajectory.rs
+++ b/aerosim-core/src/trajectory.rs
@@ -7,6 +7,7 @@ use std::{error::Error, io::Write};
 use aerosim_data::types::{ActorState, Pose, Quaternion, TimeStamp, Vector3, VehicleState};
 
 use csv::Reader;
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 use crate::{
@@ -85,15 +86,6 @@ fn generate_cubic_spline(times: &[f64], values: &[f64]) -> CubicSpline {
 /// origin_latlonalt: optional origin latitude, longitude, altitude, defaults to first point
 /// ellipsoid: optional ellipsoid, defaults to WGS84
 /// returns: list of vehicle states
-#[pyfunction]
-#[pyo3(signature = (
-    points,
-    time_step,
-    max_roll_rate_deg_per_second = 10.0,
-    curvature_to_roll_factor = 1.0,
-    origin_latlonalt = None,
-    ellipsoid = Ellipsoid::wgs84()
-))]
 pub fn generate_trajectory(
     // Each point: (time, lat, lon, alt, Option(roll), Option(pitch), Option(yaw), Option(is_ground_point))
     points: Vec<(
@@ -111,11 +103,9 @@ pub fn generate_trajectory(
     curvature_to_roll_factor: f64,
     origin_latlonalt: Option<(f64, f64, f64)>,
     ellipsoid: Ellipsoid,
-) -> PyResult<Vec<(TimeStamp, VehicleState)>> {
+) -> Result<Vec<(TimeStamp, VehicleState)>, String> {
     if points.len() < 4 {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "Spline trajectory requires at least 4 points",
-        ));
+        return Err("Spline trajectory requires at least 4 points".to_string());
     }
 
     let mut sorted_points = points;
@@ -389,18 +379,14 @@ pub fn generate_trajectory(
 /// origin_latlonalt: optional origin latitude, longitude, altitude, defaults to first point
 /// ellipsoid: optional ellipsoid, defaults to WGS84
 /// returns: list of vehicle states
-#[pyfunction]
-#[pyo3(signature = (points, time_step, origin_latlonalt=None, ellipsoid=Ellipsoid::wgs84()))]
 pub fn generate_trajectory_linear(
     points: Vec<(f64, f64, f64, f64)>,
     time_step: f64,
     origin_latlonalt: Option<(f64, f64, f64)>,
     ellipsoid: Ellipsoid,
-) -> PyResult<Vec<(TimeStamp, VehicleState)>> {
+) -> Result<Vec<(TimeStamp, VehicleState)>, String> {
     if points.len() < 2 {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "trajectory must have at least 2 points",
-        ));
+        return Err("trajectory must have at least 2 points".to_string());
     }
 
     let vec_points: Vec<(Vector3, f64)> = points
@@ -471,9 +457,7 @@ pub fn generate_trajectory_linear(
 
         let total_time = end_time - start_time;
         if total_time <= 0.0 {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "Invalid time values: end_time must be greater than start_time",
-            ));
+            return Err("Invalid time values: end_time must be greater than start_time".to_string());
         }
 
         let velocity_vector = Vector3 {
@@ -746,19 +730,6 @@ impl TrajectoryPointRecord {
     }
 }
 
-#[pyfunction]
-#[pyo3(signature = (
-    csv_filepath,
-    out_dir,
-    time_csv_column,
-    latitude_csv_column,
-    longitude_csv_column,
-    altitude_csv_column,
-    altitude_type,
-    time_type,
-    id_csv_column=None,
-    filter_id=None
-))]
 pub fn generate_trajectory_from_adsb_csv(
     csv_filepath: &str,
     out_dir: &str,
@@ -770,8 +741,8 @@ pub fn generate_trajectory_from_adsb_csv(
     time_type: &str,
     id_csv_column: Option<usize>,
     filter_id: Option<&str>,
-) -> PyResult<()> {
-    let file = File::open(csv_filepath)?;
+) -> Result<(), String> {
+    let file = File::open(csv_filepath).map_err(|e| e.to_string())?;
     let mut reader = Reader::from_reader(file);
 
     let mut single_trajectory = Vec::new();
@@ -779,7 +750,7 @@ pub fn generate_trajectory_from_adsb_csv(
 
     for record_result in reader.records() {
         let record =
-            record_result.map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+            record_result.map_err(|e| e.to_string())?;
 
         let point = TrajectoryPointRecord::from_csv_record(
             &record,
@@ -790,7 +761,7 @@ pub fn generate_trajectory_from_adsb_csv(
             altitude_type,
             time_type,
         )
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        .map_err(|e| e.to_string())?;
         if let Some(id_col) = id_csv_column {
             let csv_id_value = &record[id_col];
             if let Some(f_id) = filter_id {
@@ -819,35 +790,35 @@ pub fn generate_trajectory_from_adsb_csv(
 
     let output_path = std::path::Path::new(out_dir);
     std::fs::create_dir_all(&output_path).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Cannot create output directory: {}", e))
+        format!("Cannot create output directory: {}", e)
     })?;
 
     if id_csv_column.is_none() {
         shift_times_to_zero(&mut single_trajectory);
 
         let json_data = serde_json::to_string_pretty(&single_trajectory)
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+            .map_err(|e| e.to_string())?;
 
         let out_file_path = output_path.join("generated_trajectory.json");
         let mut out_file = File::create(&out_file_path)
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+            .map_err(|e| e.to_string())?;
         out_file
             .write_all(json_data.as_bytes())
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+            .map_err(|e| e.to_string())?;
     } else {
         if let Some(f_id) = filter_id {
             if let Some(points_for_id) = id_map.get_mut(f_id) {
                 shift_times_to_zero(points_for_id);
                 let json_data = serde_json::to_string_pretty(&points_for_id)
-                    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
                 let filename = format!("{}_generated_trajectory.json", f_id);
                 let out_file_path = output_path.join(&filename);
 
                 let mut out_file = File::create(&out_file_path)
-                    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
                 out_file
                     .write_all(json_data.as_bytes())
-                    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
             } else {
                 log::error!(
                     "No records found for filter_id '{}', no file was generated.",
@@ -858,18 +829,110 @@ pub fn generate_trajectory_from_adsb_csv(
             for (id_key, points_for_id) in id_map.iter_mut() {
                 shift_times_to_zero(points_for_id);
                 let json_data = serde_json::to_string_pretty(&points_for_id)
-                    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
                 let filename = format!("{}_generated_trajectory.json", id_key);
                 let out_file_path = output_path.join(&filename);
 
                 let mut out_file = File::create(&out_file_path)
-                    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
                 out_file
                     .write_all(json_data.as_bytes())
-                    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+                    .map_err(|e| e.to_string())?;
             }
         }
     }
 
     Ok(())
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "generate_trajectory", signature = (
+    points,
+    time_step,
+    max_roll_rate_deg_per_second = 10.0,
+    curvature_to_roll_factor = 1.0,
+    origin_latlonalt = None,
+    ellipsoid = Ellipsoid::wgs84()
+))]
+pub fn py_generate_trajectory(
+    points: Vec<(
+        f64,
+        f64,
+        f64,
+        f64,
+        Option<f64>,
+        Option<f64>,
+        Option<f64>,
+        Option<bool>,
+    )>,
+    time_step: f64,
+    max_roll_rate_deg_per_second: f64,
+    curvature_to_roll_factor: f64,
+    origin_latlonalt: Option<(f64, f64, f64)>,
+    ellipsoid: Ellipsoid,
+) -> PyResult<Vec<(TimeStamp, VehicleState)>> {
+    generate_trajectory(
+        points,
+        time_step,
+        max_roll_rate_deg_per_second,
+        curvature_to_roll_factor,
+        origin_latlonalt,
+        ellipsoid,
+    )
+    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "generate_trajectory_linear", signature = (points, time_step, origin_latlonalt=None, ellipsoid=Ellipsoid::wgs84()))]
+pub fn py_generate_trajectory_linear(
+    points: Vec<(f64, f64, f64, f64)>,
+    time_step: f64,
+    origin_latlonalt: Option<(f64, f64, f64)>,
+    ellipsoid: Ellipsoid,
+) -> PyResult<Vec<(TimeStamp, VehicleState)>> {
+    generate_trajectory_linear(points, time_step, origin_latlonalt, ellipsoid)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "generate_trajectory_from_adsb_csv", signature = (
+    csv_filepath,
+    out_dir,
+    time_csv_column,
+    latitude_csv_column,
+    longitude_csv_column,
+    altitude_csv_column,
+    altitude_type,
+    time_type,
+    id_csv_column=None,
+    filter_id=None
+))]
+pub fn py_generate_trajectory_from_adsb_csv(
+    csv_filepath: &str,
+    out_dir: &str,
+    time_csv_column: usize,
+    latitude_csv_column: usize,
+    longitude_csv_column: usize,
+    altitude_csv_column: usize,
+    altitude_type: &str,
+    time_type: &str,
+    id_csv_column: Option<usize>,
+    filter_id: Option<&str>,
+) -> PyResult<()> {
+    generate_trajectory_from_adsb_csv(
+        csv_filepath,
+        out_dir,
+        time_csv_column,
+        latitude_csv_column,
+        longitude_csv_column,
+        altitude_csv_column,
+        altitude_type,
+        time_type,
+        id_csv_column,
+        filter_id,
+    )
+    .map_err(|e| pyo3::exceptions::PyIOError::new_err(e))
 }

--- a/aerosim-core/src/trajectory.rs
+++ b/aerosim-core/src/trajectory.rs
@@ -7,6 +7,7 @@ use std::{error::Error, io::Write};
 use aerosim_data::types::{ActorState, Pose, Quaternion, TimeStamp, Vector3, VehicleState};
 
 use csv::Reader;
+
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 

--- a/aerosim-data/Cargo.toml
+++ b/aerosim-data/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "rlib"]
 aerosim-macros = { path = "../aerosim-macros" }
 chrono.workspace = true
 log.workspace = true
-pyo3.workspace = true
+pyo3 = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
@@ -24,9 +24,9 @@ bincode = "1.3"
 ctor = "0.2.8"
 enum_dispatch = "0.3.13"
 futures = "0.3.31"
-pythonize = "0.23.0"
+pythonize = { version = "0.23.0", optional = true }
 schemars = "0.8.22"
-serde_bytes="0.11.16"
+serde_bytes = "0.11.16"
 serde_repr = "0.1.20"
 turbojpeg = { version = "1.3.0", default-features = false, features = ["cmake"] }
 
@@ -34,7 +34,8 @@ turbojpeg = { version = "1.3.0", default-features = false, features = ["cmake"] 
 cmake = "0.1.57"
 
 [features]
-default = ["kafka", "zenoh"]
+default = ["python", "kafka", "zenoh"]
+python = ["pyo3", "pythonize"]
 middleware = ["r2r", "dds", "kafka", "zenoh"]
 
 dds = ["cyclors", "cdr"]

--- a/aerosim-data/src/lib.rs
+++ b/aerosim-data/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 pub mod interfaces;
@@ -8,6 +9,7 @@ pub mod middleware;
 pub use aerosim_macros::AerosimMessage;
 pub use types::AerosimMessage;
 
+#[cfg(feature = "python")]
 #[pymodule]
 fn _aerosim_data(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     let types_module = PyModule::new(py, "types")?;

--- a/aerosim-data/src/middleware/common/metadata.rs
+++ b/aerosim-data/src/middleware/common/metadata.rs
@@ -1,12 +1,14 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::TimeStamp;
 
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
 const SENTINEL_SECONDS: i32 = i32::MIN;
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct Metadata {
     pub topic: String,
@@ -20,10 +22,7 @@ pub struct Metadata {
     pub timestamp_platform: TimeStamp,
 }
 
-#[pymethods]
 impl Metadata {
-    #[new]
-    #[pyo3(signature = (topic, type_name, timestamp_sim=None, timestamp_platform=None))]
     pub fn new(
         topic: &str,
         type_name: &str,
@@ -40,6 +39,26 @@ impl Metadata {
 
     pub fn is_sim_time_valid(&self) -> bool {
         self.timestamp_sim.sec >= 0
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Metadata {
+    #[new]
+    #[pyo3(signature = (topic, type_name, timestamp_sim=None, timestamp_platform=None))]
+    fn py_new(
+        topic: &str,
+        type_name: &str,
+        timestamp_sim: Option<TimeStamp>,
+        timestamp_platform: Option<TimeStamp>,
+    ) -> Self {
+        Self::new(topic, type_name, timestamp_sim, timestamp_platform)
+    }
+
+    #[pyo3(name = "is_sim_time_valid")]
+    fn py_is_sim_time_valid(&self) -> bool {
+        self.is_sim_time_valid()
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/middleware/common/metadata.rs
+++ b/aerosim-data/src/middleware/common/metadata.rs
@@ -63,12 +63,13 @@ impl Metadata {
         self.is_sim_time_valid()
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("topic", self.topic.clone())?;
         dict.set_item("type_name", self.type_name.clone())?;
-        dict.set_item("timestamp_sim", self.timestamp_sim.to_dict(py)?)?;
-        dict.set_item("timestamp_platform", self.timestamp_platform.to_dict(py)?)?;
+        dict.set_item("timestamp_sim", self.timestamp_sim.py_to_dict(py)?)?;
+        dict.set_item("timestamp_platform", self.timestamp_platform.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 }

--- a/aerosim-data/src/middleware/common/metadata.rs
+++ b/aerosim-data/src/middleware/common/metadata.rs
@@ -42,6 +42,8 @@ impl Metadata {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl Metadata {

--- a/aerosim-data/src/middleware/dds.rs
+++ b/aerosim-data/src/middleware/dds.rs
@@ -450,13 +450,13 @@ impl PyMiddleware for DDSMiddleware {}
 #[pymethods]
 impl DDSMiddleware {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self::new())
     }
 
     #[pyo3(name = "publish")]
     #[pyo3(signature = (topic, message, timestamp_sim=None))]
-    fn pypublish(
+    fn py_publish(
         &self,
         py: Python,
         topic: &str,
@@ -467,7 +467,7 @@ impl DDSMiddleware {
     }
 
     #[pyo3(name = "subscribe")]
-    fn pysubscribe(
+    fn py_subscribe(
         &self,
         py: Python,
         message_type: PyObject,
@@ -478,7 +478,7 @@ impl DDSMiddleware {
     }
 
     #[pyo3(name = "subscribe_all")]
-    fn pysubscribe_all(
+    fn py_subscribe_all(
         &self,
         _py: Python,
         _message_type: PyObject,
@@ -491,7 +491,7 @@ impl DDSMiddleware {
     }
 
     #[pyo3(name = "publish_raw")]
-    fn pypublish_raw(
+    fn py_publish_raw(
         &self,
         py: Python,
         message_type: &str,
@@ -502,7 +502,7 @@ impl DDSMiddleware {
     }
 
     #[pyo3(name = "subscribe_raw")]
-    fn pysubscribe_raw(
+    fn py_subscribe_raw(
         &self,
         py: Python<'_>,
         message_type: &str,
@@ -513,7 +513,7 @@ impl DDSMiddleware {
     }
 
     #[pyo3(name = "subscribe_all_raw")]
-    fn pysubscribe_all_raw(
+    fn py_subscribe_all_raw(
         &self,
         _py: Python,
         _topics: Vec<(String, String)>,
@@ -532,12 +532,12 @@ impl PySerializer for DDSSerializer {}
 #[pymethods]
 impl DDSSerializer {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self {})
     }
 
     #[pyo3(name = "serialize_message")]
-    fn pyserialize_message(
+    fn py_serialize_message(
         &self,
         py: Python<'_>,
         metadata: Metadata,
@@ -548,7 +548,7 @@ impl DDSSerializer {
     }
 
     #[pyo3(name = "deserialize_message")]
-    fn pydeserialize_message(
+    fn py_deserialize_message(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -559,7 +559,7 @@ impl DDSSerializer {
     }
 
     #[pyo3(name = "deserialize_metadata")]
-    fn pydeserialize_metadata(
+    fn py_deserialize_metadata(
         &self,
         py: Python<'_>,
         payload: &[u8],
@@ -569,7 +569,7 @@ impl DDSSerializer {
     }
 
     #[pyo3(name = "deserialize_data")]
-    fn pydeserialize_data(
+    fn py_deserialize_data(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -580,7 +580,7 @@ impl DDSSerializer {
     }
 
     #[pyo3(name = "from_json")]
-    fn pyserialize_from_json(
+    fn py_serialize_from_json(
         &self,
         py: Python<'_>,
         type_name: &str,
@@ -592,7 +592,7 @@ impl DDSSerializer {
     }
 
     #[pyo3(name = "to_json")]
-    fn pydeserialize_to_json(
+    fn py_deserialize_to_json(
         &self,
         py: Python<'_>,
         type_name: &str,

--- a/aerosim-data/src/middleware/dds.rs
+++ b/aerosim-data/src/middleware/dds.rs
@@ -7,15 +7,19 @@ use std::{
 
 use async_trait::async_trait;
 use cdr::{CdrLe, Infinite};
-use pyo3::{exceptions::PyRuntimeError, prelude::*};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     middleware::{
-        CallbackClosureRaw, Metadata, Middleware, MiddlewareRaw, PyMiddleware, PySerializer,
-        Serializer, SerializerEnum,
+        CallbackClosureRaw, Metadata, Middleware, MiddlewareRaw, Serializer, SerializerEnum,
     },
     types::TimeStamp,
+};
+
+#[cfg(feature = "python")]
+use {
+    crate::middleware::{PyMiddleware, PySerializer},
+    pyo3::{exceptions::PyRuntimeError, prelude::*},
 };
 
 // Safe abstraction for cyclonedds and cyclors.
@@ -283,7 +287,7 @@ mod cyclonedds {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct DDSSerializer;
 
 impl Serializer for DDSSerializer {
@@ -300,7 +304,7 @@ impl Serializer for DDSSerializer {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct DDSMiddleware {
     participant: cyclonedds::DDSParticipant,
     writers: Mutex<HashMap<String, Arc<cyclonedds::DDSWriter>>>,
@@ -437,8 +441,10 @@ impl Middleware for DDSMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PyMiddleware for DDSMiddleware {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl DDSMiddleware {
     #[new]
@@ -517,8 +523,10 @@ impl DDSMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PySerializer for DDSSerializer {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl DDSSerializer {
     #[new]
@@ -591,5 +599,4 @@ impl DDSSerializer {
         let serializer = SerializerEnum::from(DDSSerializer {});
         self.pydeserialize_to_json_impl(py, &serializer, type_name, payload)
     }
-
 }

--- a/aerosim-data/src/middleware/dds.rs
+++ b/aerosim-data/src/middleware/dds.rs
@@ -441,6 +441,8 @@ impl Middleware for DDSMiddleware {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 impl PyMiddleware for DDSMiddleware {}
 

--- a/aerosim-data/src/middleware/kafka.rs
+++ b/aerosim-data/src/middleware/kafka.rs
@@ -297,6 +297,8 @@ impl Middleware for KafkaMiddleware {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 impl PyMiddleware for KafkaMiddleware {}
 

--- a/aerosim-data/src/middleware/kafka.rs
+++ b/aerosim-data/src/middleware/kafka.rs
@@ -306,13 +306,13 @@ impl PyMiddleware for KafkaMiddleware {}
 #[pymethods]
 impl KafkaMiddleware {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self::new())
     }
 
     #[pyo3(name = "publish")]
     #[pyo3(signature = (topic, message, timestamp_sim=None))]
-    fn pypublish(
+    fn py_publish(
         &self,
         py: Python,
         topic: &str,
@@ -323,7 +323,7 @@ impl KafkaMiddleware {
     }
 
     #[pyo3(name = "subscribe")]
-    fn pysubscribe(
+    fn py_subscribe(
         &self,
         py: Python,
         message_type: PyObject,
@@ -337,7 +337,7 @@ impl KafkaMiddleware {
     }
 
     #[pyo3(name = "subscribe_all")]
-    fn pysubscribe_all(
+    fn py_subscribe_all(
         &self,
         py: Python,
         message_type: PyObject,
@@ -351,7 +351,7 @@ impl KafkaMiddleware {
     }
 
     #[pyo3(name = "publish_raw")]
-    fn pypublish_raw(
+    fn py_publish_raw(
         &self,
         py: Python,
         message_type: &str,
@@ -362,7 +362,7 @@ impl KafkaMiddleware {
     }
 
     #[pyo3(name = "subscribe_raw")]
-    fn pysubscribe_raw(
+    fn py_subscribe_raw(
         &self,
         py: Python<'_>,
         message_type: &str,
@@ -376,7 +376,7 @@ impl KafkaMiddleware {
     }
 
     #[pyo3(name = "subscribe_all_raw")]
-    fn pysubscribe_all_raw(
+    fn py_subscribe_all_raw(
         &self,
         py: Python,
         topics: Vec<(String, String)>,
@@ -396,12 +396,12 @@ impl PySerializer for KafkaSerializer {}
 #[pymethods]
 impl KafkaSerializer {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self {})
     }
 
     #[pyo3(name = "serialize_message")]
-    fn pyserialize_message(
+    fn py_serialize_message(
         &self,
         py: Python<'_>,
         metadata: Metadata,
@@ -412,7 +412,7 @@ impl KafkaSerializer {
     }
 
     #[pyo3(name = "deserialize_message")]
-    fn pydeserialize_message(
+    fn py_deserialize_message(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -423,13 +423,13 @@ impl KafkaSerializer {
     }
 
     #[pyo3(name = "deserialize_metadata")]
-    fn pydeserialize_metadata(&self, py: Python<'_>, payload: &[u8]) -> Option<Metadata> {
+    fn py_deserialize_metadata(&self, py: Python<'_>, payload: &[u8]) -> Option<Metadata> {
         let serializer = SerializerEnum::from(KafkaSerializer {});
         self.pydeserialize_metadata_impl(py, &serializer, payload)
     }
 
     #[pyo3(name = "deserialize_data")]
-    fn pydeserialize_data(
+    fn py_deserialize_data(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -440,7 +440,7 @@ impl KafkaSerializer {
     }
 
     #[pyo3(name = "from_json")]
-    fn pyserialize_from_json(
+    fn py_serialize_from_json(
         &self,
         py: Python<'_>,
         type_name: &str,
@@ -452,7 +452,7 @@ impl KafkaSerializer {
     }
 
     #[pyo3(name = "to_json")]
-    fn pydeserialize_to_json(
+    fn py_deserialize_to_json(
         &self,
         py: Python<'_>,
         type_name: &str,

--- a/aerosim-data/src/middleware/kafka.rs
+++ b/aerosim-data/src/middleware/kafka.rs
@@ -6,7 +6,6 @@ use std::{
 
 use async_trait::async_trait;
 use futures_util::StreamExt;
-use pyo3::prelude::*;
 use rdkafka::{
     admin::{AdminClient, AdminOptions, NewTopic, TopicReplication},
     client::DefaultClientContext,
@@ -19,15 +18,18 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use tokio::task;
 
-use crate::{
-    middleware::{
-        CallbackClosureRaw, Metadata, Middleware, MiddlewareRaw, PyMiddleware, PySerializer,
-        Serializer, SerializerEnum,
-    },
-    types::TimeStamp,
+use crate::middleware::{
+    CallbackClosureRaw, Middleware, MiddlewareRaw, Serializer, SerializerEnum,
 };
 
-#[pyclass]
+#[cfg(feature = "python")]
+use {
+    crate::middleware::{Metadata, PyMiddleware, PySerializer},
+    crate::types::TimeStamp,
+    pyo3::prelude::*,
+};
+
+#[cfg_attr(feature = "python", pyclass)]
 pub struct KafkaSerializer;
 
 impl Serializer for KafkaSerializer {
@@ -44,9 +46,10 @@ impl Serializer for KafkaSerializer {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct KafkaMiddleware {
-    runtime: Arc<tokio::runtime::Runtime>,
+    #[allow(dead_code)]
+    runtime: Arc<tokio::runtime::Runtime>, // Used only in #[pymethods] when python feature is enabled
     admin: OnceLock<AdminClient<DefaultClientContext>>,
     producer: OnceLock<Arc<FutureProducer>>,
     consumers: Mutex<Vec<Arc<StreamConsumer>>>,
@@ -175,16 +178,15 @@ impl MiddlewareRaw for KafkaMiddleware {
                 )
             })),
         };
-        match producer
+        producer
             .send(
                 FutureRecord::to(topic).key("key").payload(payload),
                 Duration::from_secs(0),
             )
             .await
-        {
-            Ok(_) => {}
-            Err(e) => println!("Failed to publish topic {} with error: {:?}", topic, e.0),
-        };
+            .map_err(|e| -> Box<dyn Error> {
+                format!("Failed to publish topic {} with error: {:?}", topic, e.0).into()
+            })?;
 
         Ok(())
     }
@@ -295,8 +297,10 @@ impl Middleware for KafkaMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PyMiddleware for KafkaMiddleware {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl KafkaMiddleware {
     #[new]
@@ -383,8 +387,10 @@ impl KafkaMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PySerializer for KafkaSerializer {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl KafkaSerializer {
     #[new]

--- a/aerosim-data/src/middleware/mod.rs
+++ b/aerosim-data/src/middleware/mod.rs
@@ -8,11 +8,16 @@ use std::{
 use async_trait::async_trait;
 use ctor::ctor;
 use enum_dispatch::enum_dispatch;
-use pyo3::{exceptions::PyRuntimeError, prelude::*};
-use pythonize::{depythonize, pythonize};
 use serde::{Deserialize, Serialize};
 
-use crate::types::{AerosimMessage, PyTypeSupport, TimeStamp, TypeRegistry};
+use crate::types::{AerosimMessage, TimeStamp, TypeRegistry};
+
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{exceptions::PyRuntimeError, prelude::*},
+    pythonize::{depythonize, pythonize},
+};
 
 pub mod common;
 pub mod no_middleware;
@@ -105,6 +110,7 @@ pub trait Serializer {
     }
 }
 
+#[cfg(feature = "python")]
 pub trait PySerializer: Serializer {
     fn pyserialize_message_impl(
         &self,
@@ -287,6 +293,7 @@ pub trait Middleware: MiddlewareRaw {
     }
 }
 
+#[cfg(feature = "python")]
 #[allow(dead_code)]
 trait PyMiddleware: Middleware {
     async fn pypublish_impl(
@@ -312,7 +319,7 @@ trait PyMiddleware: Middleware {
             )))?;
         self.publish_raw(&type_support.type_name, topic, &payload)
             .await
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to publish topic data: {}", e)))
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
     async fn pysubscribe_impl(
@@ -415,7 +422,7 @@ trait PyMiddleware: Middleware {
     ) -> PyResult<()> {
         self.publish_raw(message_type, topic, payload.as_bytes(py))
             .await
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to publish topic data: {}", e)))
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
     async fn pysubscribe_raw_impl(

--- a/aerosim-data/src/middleware/no_middleware.rs
+++ b/aerosim-data/src/middleware/no_middleware.rs
@@ -44,9 +44,6 @@ impl MiddlewareRaw for NoMiddleware {
     }
 }
 
-#[cfg(feature = "python")]
-impl PyMiddleware for NoMiddleware {}
-
 #[async_trait]
 impl Middleware for NoMiddleware {
     fn get_serializer(&self) -> SerializerEnum {
@@ -70,3 +67,8 @@ impl Serializer for NoSerializer {
         None
     }
 }
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+impl PyMiddleware for NoMiddleware {}

--- a/aerosim-data/src/middleware/no_middleware.rs
+++ b/aerosim-data/src/middleware/no_middleware.rs
@@ -1,15 +1,18 @@
-use crate::middleware::{
-    CallbackClosureRaw, Middleware, MiddlewareRaw, PyMiddleware, Serializer, SerializerEnum,
-};
+use crate::middleware::{CallbackClosureRaw, Middleware, MiddlewareRaw, Serializer, SerializerEnum};
 use async_trait::async_trait;
-use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
+
+#[cfg(feature = "python")]
+use {
+    pyo3::prelude::*,
+    crate::middleware::PyMiddleware,
+};
 
 //Dummy middleware/serializer types to allow this crate to be built without any
 // middleware dependencies for crates that only need the data types by importing
 // with 'default-features = false'
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct NoMiddleware {}
 
 #[async_trait]
@@ -41,6 +44,7 @@ impl MiddlewareRaw for NoMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PyMiddleware for NoMiddleware {}
 
 #[async_trait]
@@ -50,7 +54,7 @@ impl Middleware for NoMiddleware {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct NoSerializer;
 
 impl Serializer for NoSerializer {

--- a/aerosim-data/src/middleware/serializers/bincode.rs
+++ b/aerosim-data/src/middleware/serializers/bincode.rs
@@ -1,11 +1,15 @@
-use pyo3::prelude::*;
-
 use bincode;
 use serde::{Deserialize, Serialize};
 
-use crate::middleware::{Metadata, PySerializer, Serializer, SerializerEnum};
+use crate::middleware::{Serializer, SerializerEnum};
 
-#[pyclass]
+#[cfg(feature = "python")]
+use {
+    crate::middleware::{Metadata, PySerializer},
+    pyo3::prelude::*,
+};
+
+#[cfg_attr(feature = "python", pyclass)]
 pub struct BincodeSerializer;
 
 impl Serializer for BincodeSerializer {
@@ -22,8 +26,10 @@ impl Serializer for BincodeSerializer {
     }
 }
 
+#[cfg(feature = "python")]
 impl PySerializer for BincodeSerializer {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl BincodeSerializer {
     #[new]

--- a/aerosim-data/src/middleware/serializers/bincode.rs
+++ b/aerosim-data/src/middleware/serializers/bincode.rs
@@ -26,6 +26,8 @@ impl Serializer for BincodeSerializer {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 impl PySerializer for BincodeSerializer {}
 

--- a/aerosim-data/src/middleware/serializers/bincode.rs
+++ b/aerosim-data/src/middleware/serializers/bincode.rs
@@ -35,12 +35,12 @@ impl PySerializer for BincodeSerializer {}
 #[pymethods]
 impl BincodeSerializer {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self {})
     }
 
     #[pyo3(name = "serialize_message")]
-    fn pyserialize_message(
+    fn py_serialize_message(
         &self,
         py: Python<'_>,
         metadata: Metadata,
@@ -51,7 +51,7 @@ impl BincodeSerializer {
     }
 
     #[pyo3(name = "deserialize_message")]
-    fn pydeserialize_message(
+    fn py_deserialize_message(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -62,13 +62,13 @@ impl BincodeSerializer {
     }
 
     #[pyo3(name = "deserialize_metadata")]
-    fn pydeserialize_metadata(&self, py: Python<'_>, payload: &[u8]) -> Option<Metadata> {
+    fn py_deserialize_metadata(&self, py: Python<'_>, payload: &[u8]) -> Option<Metadata> {
         let serializer = SerializerEnum::from(BincodeSerializer {});
         self.pydeserialize_metadata_impl(py, &serializer, payload)
     }
 
     #[pyo3(name = "deserialize_data")]
-    fn pydeserialize_data(
+    fn py_deserialize_data(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -79,7 +79,7 @@ impl BincodeSerializer {
     }
 
     #[pyo3(name = "from_json")]
-    fn pyserialize_from_json(
+    fn py_serialize_from_json(
         &self,
         py: Python<'_>,
         type_name: &str,
@@ -91,7 +91,7 @@ impl BincodeSerializer {
     }
 
     #[pyo3(name = "to_json")]
-    fn pydeserialize_to_json(
+    fn py_deserialize_to_json(
         &self,
         py: Python<'_>,
         type_name: &str,

--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -2,21 +2,23 @@ use std::{error::Error, sync::Arc};
 
 use async_trait::async_trait;
 use log::{error, info};
-use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-use crate::{
-    middleware::{
-        CallbackClosureRaw, Metadata, Middleware, MiddlewareRaw, PyMiddleware, PySerializer,
-        Serializer, SerializerEnum,
-    },
-    types::TimeStamp,
+use crate::middleware::{
+    CallbackClosureRaw, Middleware, MiddlewareRaw, Serializer, SerializerEnum,
 };
 
-#[pyclass]
+#[cfg(feature = "python")]
+use {
+    crate::middleware::{Metadata, PyMiddleware, PySerializer},
+    crate::types::TimeStamp,
+    pyo3::prelude::*,
+};
+
+#[cfg_attr(feature = "python", pyclass)]
 pub struct ZenohSerializer;
 
 impl Serializer for ZenohSerializer {
@@ -33,7 +35,7 @@ impl Serializer for ZenohSerializer {
     }
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct ZenohMiddleware {
     session: tokio::sync::OnceCell<zenoh::Session>,
     runtime: Arc<tokio::runtime::Runtime>,
@@ -102,7 +104,9 @@ impl MiddlewareRaw for ZenohMiddleware {
             .put(topic, payload)
             .congestion_control(zenoh::qos::CongestionControl::Block)
             .await
-            .expect("Failed to publish message");
+            .map_err(|e| -> Box<dyn Error> {
+                format!("Failed to publish topic {} with error: {}", topic, e).into()
+            })?;
 
         Ok(())
     }
@@ -176,8 +180,10 @@ impl Middleware for ZenohMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PyMiddleware for ZenohMiddleware {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl ZenohMiddleware {
     #[new]
@@ -311,8 +317,10 @@ impl ZenohMiddleware {
     }
 }
 
+#[cfg(feature = "python")]
 impl PySerializer for ZenohSerializer {}
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl ZenohSerializer {
     #[new]

--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -189,20 +189,20 @@ impl PyMiddleware for ZenohMiddleware {}
 #[pymethods]
 impl ZenohMiddleware {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self::new())
     }
 
     /// Close the Zenoh middleware, cancelling all subscriber tasks and closing the session.
     /// This should be called before the Python process exits to ensure clean shutdown.
     #[pyo3(name = "close")]
-    fn pyclose(&self) {
+    fn py_close(&self) {
         self.shutdown();
     }
 
     #[pyo3(name = "publish")]
     #[pyo3(signature = (topic, message, timestamp_sim=None))]
-    fn pypublish(
+    fn py_publish(
         &self,
         py: Python,
         topic: &str,
@@ -221,7 +221,7 @@ impl ZenohMiddleware {
     }
 
     #[pyo3(name = "subscribe")]
-    fn pysubscribe(
+    fn py_subscribe(
         &self,
         py: Python,
         message_type: PyObject,
@@ -241,7 +241,7 @@ impl ZenohMiddleware {
     }
 
     #[pyo3(name = "subscribe_all")]
-    fn pysubscribe_all(
+    fn py_subscribe_all(
         &self,
         py: Python,
         message_type: PyObject,
@@ -261,7 +261,7 @@ impl ZenohMiddleware {
     }
 
     #[pyo3(name = "publish_raw")]
-    fn pypublish_raw(
+    fn py_publish_raw(
         &self,
         py: Python,
         message_type: &str,
@@ -281,7 +281,7 @@ impl ZenohMiddleware {
     }
 
     #[pyo3(name = "subscribe_raw")]
-    fn pysubscribe_raw(
+    fn py_subscribe_raw(
         &self,
         py: Python<'_>,
         message_type: &str,
@@ -301,7 +301,7 @@ impl ZenohMiddleware {
     }
 
     #[pyo3(name = "subscribe_all_raw")]
-    fn pysubscribe_all_raw(
+    fn py_subscribe_all_raw(
         &self,
         py: Python,
         topics: Vec<(String, String)>,
@@ -326,12 +326,12 @@ impl PySerializer for ZenohSerializer {}
 #[pymethods]
 impl ZenohSerializer {
     #[new]
-    fn pynew(_py: Python) -> PyResult<Self> {
+    fn py_new(_py: Python) -> PyResult<Self> {
         Ok(Self {})
     }
 
     #[pyo3(name = "serialize_message")]
-    fn pyserialize_message(
+    fn py_serialize_message(
         &self,
         py: Python<'_>,
         metadata: Metadata,
@@ -342,7 +342,7 @@ impl ZenohSerializer {
     }
 
     #[pyo3(name = "deserialize_message")]
-    fn pydeserialize_message(
+    fn py_deserialize_message(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -353,13 +353,13 @@ impl ZenohSerializer {
     }
 
     #[pyo3(name = "deserialize_metadata")]
-    fn pydeserialize_metadata(&self, py: Python<'_>, payload: &[u8]) -> Option<Metadata> {
+    fn py_deserialize_metadata(&self, py: Python<'_>, payload: &[u8]) -> Option<Metadata> {
         let serializer = SerializerEnum::from(ZenohSerializer {});
         self.pydeserialize_metadata_impl(py, &serializer, payload)
     }
 
     #[pyo3(name = "deserialize_data")]
-    fn pydeserialize_data(
+    fn py_deserialize_data(
         &self,
         py: Python<'_>,
         message_type: PyObject,
@@ -370,7 +370,7 @@ impl ZenohSerializer {
     }
 
     #[pyo3(name = "from_json")]
-    fn pyserialize_from_json(
+    fn py_serialize_from_json(
         &self,
         py: Python<'_>,
         type_name: &str,
@@ -382,7 +382,7 @@ impl ZenohSerializer {
     }
 
     #[pyo3(name = "to_json")]
-    fn pydeserialize_to_json(
+    fn py_deserialize_to_json(
         &self,
         py: Python<'_>,
         type_name: &str,

--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -180,6 +180,8 @@ impl Middleware for ZenohMiddleware {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 impl PyMiddleware for ZenohMiddleware {}
 

--- a/aerosim-data/src/types/actor.rs
+++ b/aerosim-data/src/types/actor.rs
@@ -26,6 +26,54 @@ pub struct Actor {
     pub parent_actor_uid: Option<u64>,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
+pub struct ActorState {
+    pub pose: Pose,
+}
+
+impl ActorState {
+    pub fn new(pose: Pose) -> Self {
+        ActorState { pose }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct ActorModel {
+    pub physical_properties: PhysicalProperties,
+    pub asset_link: Option<String>,
+}
+
+impl ActorModel {
+    pub fn new(physical_properties: PhysicalProperties, asset_link: Option<String>) -> Self {
+        ActorModel {
+            physical_properties,
+            asset_link,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct PhysicalProperties {
+    pub mass: f64,
+    pub inertia_tensor: Vector3,
+    pub moment_of_inertia: Vector3,
+}
+
+impl PhysicalProperties {
+    pub fn new(mass: f64, inertia_tensor: Vector3, moment_of_inertia: Vector3) -> Self {
+        PhysicalProperties {
+            mass,
+            inertia_tensor,
+            moment_of_inertia,
+        }
+    }
+}
+
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl Actor {
@@ -70,18 +118,6 @@ impl Actor {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all))]
-pub struct ActorState {
-    pub pose: Pose,
-}
-
-impl ActorState {
-    pub fn new(pose: Pose) -> Self {
-        ActorState { pose }
-    }
-}
-
 #[cfg(feature = "python")]
 #[pymethods]
 impl ActorState {
@@ -105,22 +141,6 @@ impl ActorState {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct ActorModel {
-    pub physical_properties: PhysicalProperties,
-    pub asset_link: Option<String>,
-}
-
-impl ActorModel {
-    pub fn new(physical_properties: PhysicalProperties, asset_link: Option<String>) -> Self {
-        ActorModel {
-            physical_properties,
-            asset_link,
-        }
-    }
-}
-
 #[cfg(feature = "python")]
 #[pymethods]
 impl ActorModel {
@@ -135,24 +155,6 @@ impl ActorModel {
         dict.set_item("physical_properties", self.physical_properties.to_dict(py)?)?;
         dict.set_item("asset_link", self.asset_link.clone())?;
         Ok(dict.into())
-    }
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct PhysicalProperties {
-    pub mass: f64,
-    pub inertia_tensor: Vector3,
-    pub moment_of_inertia: Vector3,
-}
-
-impl PhysicalProperties {
-    pub fn new(mass: f64, inertia_tensor: Vector3, moment_of_inertia: Vector3) -> Self {
-        PhysicalProperties {
-            mass,
-            inertia_tensor,
-            moment_of_inertia,
-        }
     }
 }
 

--- a/aerosim-data/src/types/actor.rs
+++ b/aerosim-data/src/types/actor.rs
@@ -2,10 +2,11 @@ use super::geometry::{Pose, Vector3};
 use super::sensor::SensorType;
 use super::vehicle::VehicleType;
 
-use pyo3::prelude::*;
-use pyo3::types::PyDict;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 // PyO3 only supports unit variants for enums. Variant with data is not supported
@@ -16,30 +17,77 @@ pub enum ActorType {
 
 // PyO3 only supports unit variants for enums so we need to use a struct instead
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct Actor {
-    #[pyo3(get, set)]
     pub uid: u64,
     pub actor_type: ActorType,
-    #[pyo3(get, set)]
     pub state: ActorState,
-    #[pyo3(get, set)]
     pub model: ActorModel,
-    #[pyo3(get, set)]
     pub parent_actor_uid: Option<u64>,
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
+impl Actor {
+    #[getter]
+    fn uid(&self) -> u64 {
+        self.uid
+    }
+
+    #[setter]
+    fn set_uid(&mut self, uid: u64) {
+        self.uid = uid;
+    }
+
+    #[getter]
+    fn state(&self) -> ActorState {
+        self.state.clone()
+    }
+
+    #[setter]
+    fn set_state(&mut self, state: ActorState) {
+        self.state = state;
+    }
+
+    #[getter]
+    fn model(&self) -> ActorModel {
+        self.model.clone()
+    }
+
+    #[setter]
+    fn set_model(&mut self, model: ActorModel) {
+        self.model = model;
+    }
+
+    #[getter]
+    fn parent_actor_uid(&self) -> Option<u64> {
+        self.parent_actor_uid
+    }
+
+    #[setter]
+    fn set_parent_actor_uid(&mut self, parent_actor_uid: Option<u64>) {
+        self.parent_actor_uid = parent_actor_uid;
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct ActorState {
     pub pose: Pose,
 }
 
+impl ActorState {
+    pub fn new(pose: Pose) -> Self {
+        ActorState { pose }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl ActorState {
     #[new]
-    pub fn new(pose: Pose) -> Self {
-        ActorState { pose }
+    fn py_new(pose: Pose) -> Self {
+        Self::new(pose)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -58,21 +106,28 @@ impl ActorState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct ActorModel {
     pub physical_properties: PhysicalProperties,
     pub asset_link: Option<String>,
 }
 
-#[pymethods]
 impl ActorModel {
-    #[new]
-    #[pyo3(signature = (physical_properties, asset_link=None))]
     pub fn new(physical_properties: PhysicalProperties, asset_link: Option<String>) -> Self {
         ActorModel {
             physical_properties,
             asset_link,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ActorModel {
+    #[new]
+    #[pyo3(signature = (physical_properties, asset_link=None))]
+    fn py_new(physical_properties: PhysicalProperties, asset_link: Option<String>) -> Self {
+        Self::new(physical_properties, asset_link)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -84,22 +139,29 @@ impl ActorModel {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct PhysicalProperties {
     pub mass: f64,
     pub inertia_tensor: Vector3,
     pub moment_of_inertia: Vector3,
 }
 
-#[pymethods]
 impl PhysicalProperties {
-    #[new]
     pub fn new(mass: f64, inertia_tensor: Vector3, moment_of_inertia: Vector3) -> Self {
         PhysicalProperties {
             mass,
             inertia_tensor,
             moment_of_inertia,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PhysicalProperties {
+    #[new]
+    fn py_new(mass: f64, inertia_tensor: Vector3, moment_of_inertia: Vector3) -> Self {
+        Self::new(mass, inertia_tensor, moment_of_inertia)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/actor.rs
+++ b/aerosim-data/src/types/actor.rs
@@ -126,9 +126,10 @@ impl ActorState {
         Self::new(pose)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("pose", self.pose.to_dict(py)?)?;
+        dict.set_item("pose", self.pose.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 
@@ -150,9 +151,10 @@ impl ActorModel {
         Self::new(physical_properties, asset_link)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("physical_properties", self.physical_properties.to_dict(py)?)?;
+        dict.set_item("physical_properties", self.physical_properties.py_to_dict(py)?)?;
         dict.set_item("asset_link", self.asset_link.clone())?;
         Ok(dict.into())
     }
@@ -166,11 +168,12 @@ impl PhysicalProperties {
         Self::new(mass, inertia_tensor, moment_of_inertia)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("mass", self.mass)?;
-        dict.set_item("inertia_tensor", self.inertia_tensor.to_dict(py)?)?;
-        dict.set_item("moment_of_inertia", self.moment_of_inertia.to_dict(py)?)?;
+        dict.set_item("inertia_tensor", self.inertia_tensor.py_to_dict(py)?)?;
+        dict.set_item("moment_of_inertia", self.moment_of_inertia.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 }

--- a/aerosim-data/src/types/adsb/airborne_position.rs
+++ b/aerosim-data/src/types/adsb/airborne_position.rs
@@ -1,10 +1,12 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::types::SurveillanceStatus;
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AirbornePosition {
     /// Type Code
@@ -27,6 +29,7 @@ pub struct AirbornePosition {
     pub lon_cpr: u32,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AirbornePosition {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/airborne_position.rs
+++ b/aerosim-data/src/types/adsb/airborne_position.rs
@@ -29,6 +29,8 @@ pub struct AirbornePosition {
     pub lon_cpr: u32,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl AirbornePosition {

--- a/aerosim-data/src/types/adsb/airborne_position.rs
+++ b/aerosim-data/src/types/adsb/airborne_position.rs
@@ -34,7 +34,8 @@ pub struct AirbornePosition {
 #[cfg(feature = "python")]
 #[pymethods]
 impl AirbornePosition {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("tc", self.tc)?;
         let _ = dict.set_item("ss", self.ss as u8)?;
@@ -53,6 +54,6 @@ impl AirbornePosition {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/airborne_velocity.rs
+++ b/aerosim-data/src/types/adsb/airborne_velocity.rs
@@ -29,6 +29,8 @@ pub struct AirborneVelocity {
     pub vertical_rate: Option<i16>,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl AirborneVelocity {

--- a/aerosim-data/src/types/adsb/airborne_velocity.rs
+++ b/aerosim-data/src/types/adsb/airborne_velocity.rs
@@ -34,7 +34,8 @@ pub struct AirborneVelocity {
 #[cfg(feature = "python")]
 #[pymethods]
 impl AirborneVelocity {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("st", self.st)?;
         let _ = dict.set_item("nac_v", self.nac_v)?;
@@ -55,6 +56,6 @@ impl AirborneVelocity {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/airborne_velocity.rs
+++ b/aerosim-data/src/types/adsb/airborne_velocity.rs
@@ -1,8 +1,10 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AirborneVelocity {
     /// Velocity subtype
@@ -27,6 +29,7 @@ pub struct AirborneVelocity {
     pub vertical_rate: Option<i16>,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AirborneVelocity {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/aircraft_identification.rs
+++ b/aerosim-data/src/types/adsb/aircraft_identification.rs
@@ -15,6 +15,8 @@ pub struct AircraftIdentification {
     pub cn: String,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftIdentification {

--- a/aerosim-data/src/types/adsb/aircraft_identification.rs
+++ b/aerosim-data/src/types/adsb/aircraft_identification.rs
@@ -20,7 +20,8 @@ pub struct AircraftIdentification {
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftIdentification {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("tc", self.tc)?;
         let _ = dict.set_item("ca", self.ca)?;
@@ -29,6 +30,6 @@ impl AircraftIdentification {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/aircraft_identification.rs
+++ b/aerosim-data/src/types/adsb/aircraft_identification.rs
@@ -1,8 +1,10 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AircraftIdentification {
     /// Type Code
@@ -13,6 +15,7 @@ pub struct AircraftIdentification {
     pub cn: String,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AircraftIdentification {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/aircraft_operation_status.rs
+++ b/aerosim-data/src/types/adsb/aircraft_operation_status.rs
@@ -21,6 +21,24 @@ pub struct AircraftOperationStatusAirborne {
     pub sil_supplement: u8,
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all))]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct AircraftOperationStatusSurface {
+    pub capability_class: CapabilityClassSurface,
+    pub lw_codes: u8,
+    pub operational_mode: OperationalMode,
+    pub gps_antenna_offset: u8,
+    pub version_number: ADSBVersion,
+    pub nic_supplement_a: u8,
+    pub navigational_accuracy_category: u8,
+    pub source_integrity_level: u8,
+    pub barometric_altitude_integrity: u8,
+    pub horizontal_reference_direction: u8,
+    pub sil_supplement: u8,
+}
+
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftOperationStatusAirborne {
@@ -54,22 +72,6 @@ impl AircraftOperationStatusAirborne {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
         self.to_dict(py)
     }
-}
-
-#[cfg_attr(feature = "python", pyclass(get_all))]
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
-pub struct AircraftOperationStatusSurface {
-    pub capability_class: CapabilityClassSurface,
-    pub lw_codes: u8,
-    pub operational_mode: OperationalMode,
-    pub gps_antenna_offset: u8,
-    pub version_number: ADSBVersion,
-    pub nic_supplement_a: u8,
-    pub navigational_accuracy_category: u8,
-    pub source_integrity_level: u8,
-    pub barometric_altitude_integrity: u8,
-    pub horizontal_reference_direction: u8,
-    pub sil_supplement: u8,
 }
 
 #[cfg(feature = "python")]

--- a/aerosim-data/src/types/adsb/aircraft_operation_status.rs
+++ b/aerosim-data/src/types/adsb/aircraft_operation_status.rs
@@ -1,10 +1,12 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::types::{ADSBVersion, CapabilityClassAirborne, CapabilityClassSurface, OperationalMode};
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AircraftOperationStatusAirborne {
     pub capability_class: CapabilityClassAirborne,
@@ -19,6 +21,7 @@ pub struct AircraftOperationStatusAirborne {
     pub sil_supplement: u8,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AircraftOperationStatusAirborne {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -53,7 +56,7 @@ impl AircraftOperationStatusAirborne {
     }
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AircraftOperationStatusSurface {
     pub capability_class: CapabilityClassSurface,
@@ -69,6 +72,7 @@ pub struct AircraftOperationStatusSurface {
     pub sil_supplement: u8,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AircraftOperationStatusSurface {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/aircraft_operation_status.rs
+++ b/aerosim-data/src/types/adsb/aircraft_operation_status.rs
@@ -42,7 +42,8 @@ pub struct AircraftOperationStatusSurface {
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftOperationStatusAirborne {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("capability_class", self.capability_class)?;
         let _ = dict.set_item("operational_mode", self.operational_mode)?;
@@ -70,14 +71,15 @@ impl AircraftOperationStatusAirborne {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftOperationStatusSurface {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("capability_class", self.capability_class)?;
         let _ = dict.set_item("lw_codes", self.lw_codes)?;
@@ -103,6 +105,6 @@ impl AircraftOperationStatusSurface {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/aircraft_status.rs
+++ b/aerosim-data/src/types/adsb/aircraft_status.rs
@@ -13,6 +13,8 @@ pub struct AircraftStatus {
     pub squawk: u32,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftStatus {

--- a/aerosim-data/src/types/adsb/aircraft_status.rs
+++ b/aerosim-data/src/types/adsb/aircraft_status.rs
@@ -1,16 +1,19 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::adsb::types::EmergencyState;
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AircraftStatus {
     pub emergency_state: EmergencyState,
     pub squawk: u32,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AircraftStatus {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/aircraft_status.rs
+++ b/aerosim-data/src/types/adsb/aircraft_status.rs
@@ -18,7 +18,8 @@ pub struct AircraftStatus {
 #[cfg(feature = "python")]
 #[pymethods]
 impl AircraftStatus {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("emergency_state", self.emergency_state)?;
         let _ = dict.set_item("squawk", self.squawk)?;
@@ -26,6 +27,6 @@ impl AircraftStatus {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/gnss_position_data.rs
+++ b/aerosim-data/src/types/adsb/gnss_position_data.rs
@@ -38,6 +38,8 @@ impl GNSSPositionData {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl GNSSPositionData {

--- a/aerosim-data/src/types/adsb/gnss_position_data.rs
+++ b/aerosim-data/src/types/adsb/gnss_position_data.rs
@@ -57,7 +57,8 @@ impl GNSSPositionData {
         Self::new(latitude, longitude, altitude, velocity, heading, ground_velocity, acceleration)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("latitude", self.latitude)?;
         let _ = dict.set_item("longitude", self.longitude)?;
@@ -70,6 +71,6 @@ impl GNSSPositionData {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/gnss_position_data.rs
+++ b/aerosim-data/src/types/adsb/gnss_position_data.rs
@@ -1,8 +1,10 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Default, JsonSchema)]
 pub struct GNSSPositionData {
     pub latitude: f64,
@@ -14,10 +16,7 @@ pub struct GNSSPositionData {
     pub acceleration: f64,
 }
 
-#[pymethods]
 impl GNSSPositionData {
-    #[new]
-    #[pyo3(signature = (latitude=0.0, longitude=0.0, altitude=0.0, velocity=0.0, heading=0.0, ground_velocity=0.0, acceleration=0.0))]
     pub fn new(
         latitude: f64,
         longitude: f64,
@@ -36,6 +35,24 @@ impl GNSSPositionData {
             ground_velocity,
             acceleration,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl GNSSPositionData {
+    #[new]
+    #[pyo3(signature = (latitude=0.0, longitude=0.0, altitude=0.0, velocity=0.0, heading=0.0, ground_velocity=0.0, acceleration=0.0))]
+    pub fn py_new(
+        latitude: f64,
+        longitude: f64,
+        altitude: f64,
+        velocity: f64,
+        heading: f64,
+        ground_velocity: f64,
+        acceleration: f64,
+    ) -> Self {
+        Self::new(latitude, longitude, altitude, velocity, heading, ground_velocity, acceleration)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/surface_position.rs
+++ b/aerosim-data/src/types/adsb/surface_position.rs
@@ -28,7 +28,8 @@ pub struct SurfacePosition {
 #[cfg(feature = "python")]
 #[pymethods]
 impl SurfacePosition {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("mov", self.mov)?;
         let _ = dict.set_item("s", self.s)?;
@@ -41,6 +42,6 @@ impl SurfacePosition {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/surface_position.rs
+++ b/aerosim-data/src/types/adsb/surface_position.rs
@@ -1,8 +1,10 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SurfacePosition {
     /// Aircraft ground speed
@@ -21,6 +23,7 @@ pub struct SurfacePosition {
     pub lon_cpr: u32,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl SurfacePosition {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/surface_position.rs
+++ b/aerosim-data/src/types/adsb/surface_position.rs
@@ -23,6 +23,8 @@ pub struct SurfacePosition {
     pub lon_cpr: u32,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl SurfacePosition {

--- a/aerosim-data/src/types/adsb/target_state_and_status_information.rs
+++ b/aerosim-data/src/types/adsb/target_state_and_status_information.rs
@@ -25,6 +25,8 @@ pub struct TargetStateAndStatusInformation {
     pub lnav: bool,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl TargetStateAndStatusInformation {

--- a/aerosim-data/src/types/adsb/target_state_and_status_information.rs
+++ b/aerosim-data/src/types/adsb/target_state_and_status_information.rs
@@ -1,8 +1,10 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TargetStateAndStatusInformation {
     pub is_fms: bool,
@@ -23,6 +25,7 @@ pub struct TargetStateAndStatusInformation {
     pub lnav: bool,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl TargetStateAndStatusInformation {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/adsb/target_state_and_status_information.rs
+++ b/aerosim-data/src/types/adsb/target_state_and_status_information.rs
@@ -30,7 +30,8 @@ pub struct TargetStateAndStatusInformation {
 #[cfg(feature = "python")]
 #[pymethods]
 impl TargetStateAndStatusInformation {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("is_fms", self.is_fms)?;
         let _ = dict.set_item("altitude", self.altitude)?;
@@ -52,6 +53,6 @@ impl TargetStateAndStatusInformation {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }

--- a/aerosim-data/src/types/adsb/types.rs
+++ b/aerosim-data/src/types/adsb/types.rs
@@ -33,23 +33,6 @@ pub struct ADSB {
     pub pi: ICAOAddress,
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl ADSB {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        let _ = dict.set_item("capability", self.capability);
-        let _ = dict.set_item("icao", self.icao.to_hex());
-        let _ = dict.set_item("message_extended_quitter", self.me.to_dict(py)?);
-        let _ = dict.set_item("parity", self.pi.to_hex());
-        Ok(dict.into())
-    }
-
-    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
-    }
-}
-
 #[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ME {
@@ -69,33 +52,6 @@ pub enum ME {
     AircraftOperationStatusReserved(u8, [u8; 5]),
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl ME {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        match self {
-            Self::AircraftIdentification(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AirbornePosition(message_type) => Ok(message_type.to_dict(py)?),
-            Self::SurfacePosition(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AirborneVelocity(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AircraftOperationStatusAirborne(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AircraftOperationStatusSurface(message_type) => Ok(message_type.to_dict(py)?),
-            Self::TargetStateAndStatusInformation(message_type) => Ok(message_type.to_dict(py)?),
-            Self::NoPosition(_) => Ok(py.None()),
-            Self::Reserved0(_) => Ok(py.None()),
-            Self::Reserved1(_) => Ok(py.None()),
-            Self::AircraftOperationalCoordination(_) => Ok(py.None()),
-            Self::SurfaceSystemStatus(_) => Ok(py.None()),
-            Self::AircraftOperationStatusReserved(_, _) => Ok(py.None()),
-            _ => Ok(py.None()),
-        }
-    }
-
-    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
-    }
-}
-
 #[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ADSBMessageType {
@@ -110,32 +66,6 @@ pub enum ADSBMessageType {
     CommBAltitudeReply(CommBAltitudeReply),
     CommBIdentityReply(CommBIdentityReply),
     GNSSPositionData(GNSSPositionData),
-}
-
-#[cfg(feature = "python")]
-#[pymethods]
-impl ADSBMessageType {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        match self {
-            Self::ShortAirAirSurveillance(message_type) => Ok(message_type.to_dict(py)?),
-            Self::SurveillanceAltitudeReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::SurveillanceIdentityReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AllCallReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::LongAirAir(message_type) => Ok(message_type.to_dict(py)?),
-            Self::ADSB(message_type) => Ok(message_type.to_dict(py)?),
-            Self::TisB(message_type) => Ok(message_type.to_dict(py)?),
-            Self::ExtendedSquitterMilitaryApplication(message_type) => {
-                Ok(message_type.to_dict(py)?)
-            }
-            Self::CommBAltitudeReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::CommBIdentityReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::GNSSPositionData(message_type) => Ok(message_type.to_dict(py)?),
-        }
-    }
-
-    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
-    }
 }
 
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
@@ -201,26 +131,6 @@ pub struct CapabilityClassAirborne {
     pub tc: u8,
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl CapabilityClassAirborne {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        let _ = dict.set_item("reserved0", self.reserved0);
-        let _ = dict.set_item("acas", self.acas);
-        let _ = dict.set_item("cdti", self.cdti);
-        let _ = dict.set_item("reserved1", self.reserved1);
-        let _ = dict.set_item("arv", self.arv);
-        let _ = dict.set_item("ts", self.ts);
-        let _ = dict.set_item("tc", self.tc);
-        Ok(dict.into())
-    }
-
-    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
-    }
-}
-
 #[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CapabilityClassSurface {
@@ -240,26 +150,6 @@ pub struct CapabilityClassSurface {
     pub nic_supplement_c: u8,
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl CapabilityClassSurface {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        let _ = dict.set_item("reserved0", self.reserved0);
-        let _ = dict.set_item("poe", self.poe);
-        let _ = dict.set_item("es1090", self.es1090);
-        let _ = dict.set_item("b2_low", self.b2_low);
-        let _ = dict.set_item("uat_in", self.uat_in);
-        let _ = dict.set_item("nac_v", self.nac_v);
-        let _ = dict.set_item("nic_supplement_c", self.nic_supplement_c);
-        Ok(dict.into())
-    }
-
-    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
-    }
-}
-
 #[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct OperationalMode {
@@ -270,25 +160,6 @@ pub struct OperationalMode {
     pub reserved_recv_atc_service: bool,
     pub single_antenna_flag: bool,
     pub system_design_assurance: u8,
-}
-
-#[cfg(feature = "python")]
-#[pymethods]
-impl OperationalMode {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        let _ = dict.set_item("reserved", self.reserved);
-        let _ = dict.set_item("tcas_ra_active", self.tcas_ra_active);
-        let _ = dict.set_item("ident_switch_active", self.ident_switch_active);
-        let _ = dict.set_item("reserved_recv_atc_service", self.reserved_recv_atc_service);
-        let _ = dict.set_item("single_antenna_flag", self.single_antenna_flag);
-        let _ = dict.set_item("system_design_assurance", self.system_design_assurance);
-        Ok(dict.into())
-    }
-
-    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
-    }
 }
 
 #[cfg_attr(feature = "python", pyclass(eq, eq_int))]
@@ -416,18 +287,6 @@ impl SurveillanceStatus {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl SurveillanceStatus {
-    pub fn __str__(&self) -> String {
-        self.to_string()
-    }
-
-    pub fn __repr__(&self) -> String {
-        self.to_string()
-    }
-}
-
 impl From<u8> for SurveillanceStatus {
     fn from(value: u8) -> Self {
         match value {
@@ -437,5 +296,148 @@ impl From<u8> for SurveillanceStatus {
             3 => Self::SPICondition,
             _ => Self::NoCondition,
         }
+    }
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ADSB {
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        let _ = dict.set_item("capability", self.capability);
+        let _ = dict.set_item("icao", self.icao.to_hex());
+        let _ = dict.set_item("message_extended_quitter", self.me.to_dict(py)?);
+        let _ = dict.set_item("parity", self.pi.to_hex());
+        Ok(dict.into())
+    }
+
+    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
+        self.to_dict(py)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ME {
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        match self {
+            Self::AircraftIdentification(message_type) => Ok(message_type.to_dict(py)?),
+            Self::AirbornePosition(message_type) => Ok(message_type.to_dict(py)?),
+            Self::SurfacePosition(message_type) => Ok(message_type.to_dict(py)?),
+            Self::AirborneVelocity(message_type) => Ok(message_type.to_dict(py)?),
+            Self::AircraftOperationStatusAirborne(message_type) => Ok(message_type.to_dict(py)?),
+            Self::AircraftOperationStatusSurface(message_type) => Ok(message_type.to_dict(py)?),
+            Self::TargetStateAndStatusInformation(message_type) => Ok(message_type.to_dict(py)?),
+            Self::NoPosition(_) => Ok(py.None()),
+            Self::Reserved0(_) => Ok(py.None()),
+            Self::Reserved1(_) => Ok(py.None()),
+            Self::AircraftOperationalCoordination(_) => Ok(py.None()),
+            Self::SurfaceSystemStatus(_) => Ok(py.None()),
+            Self::AircraftOperationStatusReserved(_, _) => Ok(py.None()),
+            _ => Ok(py.None()),
+        }
+    }
+
+    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
+        self.to_dict(py)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ADSBMessageType {
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        match self {
+            Self::ShortAirAirSurveillance(message_type) => Ok(message_type.to_dict(py)?),
+            Self::SurveillanceAltitudeReply(message_type) => Ok(message_type.to_dict(py)?),
+            Self::SurveillanceIdentityReply(message_type) => Ok(message_type.to_dict(py)?),
+            Self::AllCallReply(message_type) => Ok(message_type.to_dict(py)?),
+            Self::LongAirAir(message_type) => Ok(message_type.to_dict(py)?),
+            Self::ADSB(message_type) => Ok(message_type.to_dict(py)?),
+            Self::TisB(message_type) => Ok(message_type.to_dict(py)?),
+            Self::ExtendedSquitterMilitaryApplication(message_type) => {
+                Ok(message_type.to_dict(py)?)
+            }
+            Self::CommBAltitudeReply(message_type) => Ok(message_type.to_dict(py)?),
+            Self::CommBIdentityReply(message_type) => Ok(message_type.to_dict(py)?),
+            Self::GNSSPositionData(message_type) => Ok(message_type.to_dict(py)?),
+        }
+    }
+
+    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
+        self.to_dict(py)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl CapabilityClassAirborne {
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        let _ = dict.set_item("reserved0", self.reserved0);
+        let _ = dict.set_item("acas", self.acas);
+        let _ = dict.set_item("cdti", self.cdti);
+        let _ = dict.set_item("reserved1", self.reserved1);
+        let _ = dict.set_item("arv", self.arv);
+        let _ = dict.set_item("ts", self.ts);
+        let _ = dict.set_item("tc", self.tc);
+        Ok(dict.into())
+    }
+
+    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
+        self.to_dict(py)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl CapabilityClassSurface {
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        let _ = dict.set_item("reserved0", self.reserved0);
+        let _ = dict.set_item("poe", self.poe);
+        let _ = dict.set_item("es1090", self.es1090);
+        let _ = dict.set_item("b2_low", self.b2_low);
+        let _ = dict.set_item("uat_in", self.uat_in);
+        let _ = dict.set_item("nac_v", self.nac_v);
+        let _ = dict.set_item("nic_supplement_c", self.nic_supplement_c);
+        Ok(dict.into())
+    }
+
+    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
+        self.to_dict(py)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl OperationalMode {
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        let _ = dict.set_item("reserved", self.reserved);
+        let _ = dict.set_item("tcas_ra_active", self.tcas_ra_active);
+        let _ = dict.set_item("ident_switch_active", self.ident_switch_active);
+        let _ = dict.set_item("reserved_recv_atc_service", self.reserved_recv_atc_service);
+        let _ = dict.set_item("single_antenna_flag", self.single_antenna_flag);
+        let _ = dict.set_item("system_design_assurance", self.system_design_assurance);
+        Ok(dict.into())
+    }
+
+    pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
+        self.to_dict(py)
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl SurveillanceStatus {
+    pub fn __str__(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn __repr__(&self) -> String {
+        self.to_string()
     }
 }

--- a/aerosim-data/src/types/adsb/types.rs
+++ b/aerosim-data/src/types/adsb/types.rs
@@ -1,4 +1,3 @@
-use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
@@ -22,7 +21,10 @@ use super::{
     target_state_and_status_information::TargetStateAndStatusInformation,
 };
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ADSB {
     pub capability: Capability,
@@ -31,6 +33,8 @@ pub struct ADSB {
     pub pi: ICAOAddress,
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
 impl ADSB {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -46,7 +50,7 @@ impl ADSB {
     }
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub enum ME {
     AircraftIdentification(AircraftIdentification),
@@ -65,6 +69,8 @@ pub enum ME {
     AircraftOperationStatusReserved(u8, [u8; 5]),
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
 impl ME {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         match self {
@@ -90,7 +96,7 @@ impl ME {
     }
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ADSBMessageType {
     ShortAirAirSurveillance(ShortAirAirSurveillance),
@@ -106,6 +112,8 @@ pub enum ADSBMessageType {
     GNSSPositionData(GNSSPositionData),
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
 impl ADSBMessageType {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         match self {
@@ -130,7 +138,7 @@ impl ADSBMessageType {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(
     Copy, Clone, Debug, Serialize, Deserialize, EnumString, Display, PartialEq, Eq, JsonSchema,
 )]
@@ -160,7 +168,7 @@ impl From<u8> for EmergencyState {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(
     Copy, Clone, Debug, Serialize, Deserialize, EnumString, Display, PartialEq, Eq, JsonSchema,
 )]
@@ -181,7 +189,7 @@ impl From<u8> for ADSBVersion {
     }
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CapabilityClassAirborne {
     pub reserved0: u8,
@@ -193,6 +201,8 @@ pub struct CapabilityClassAirborne {
     pub tc: u8,
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
 impl CapabilityClassAirborne {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -211,7 +221,7 @@ impl CapabilityClassAirborne {
     }
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CapabilityClassSurface {
     /// 0, 0 in current version, reserved as id for later versions
@@ -230,6 +240,8 @@ pub struct CapabilityClassSurface {
     pub nic_supplement_c: u8,
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
 impl CapabilityClassSurface {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -248,7 +260,7 @@ impl CapabilityClassSurface {
     }
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct OperationalMode {
     /// (0, 0) in Version 2, reserved for other values
@@ -260,6 +272,8 @@ pub struct OperationalMode {
     pub system_design_assurance: u8,
 }
 
+#[cfg(feature = "python")]
+#[pymethods]
 impl OperationalMode {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -277,7 +291,7 @@ impl OperationalMode {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, EnumString, Display, PartialEq, Eq)]
 pub enum AirborneVelocitySubType {
     Reserved,
@@ -285,7 +299,7 @@ pub enum AirborneVelocitySubType {
     AirspeedDecoding,
 }
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 pub struct ICAOAddress(pub [u8; 3]);
 
@@ -300,7 +314,7 @@ impl ICAOAddress {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum FlightStatus {
     NoAlertNoSPIAirborne,
@@ -328,7 +342,7 @@ impl From<u8> for FlightStatus {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum Capability {
     Uncertain = 0,
@@ -353,7 +367,7 @@ impl From<u8> for Capability {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, JsonSchema)]
 #[allow(non_camel_case_types)]
 pub enum ControlFieldType {
@@ -382,7 +396,7 @@ impl From<u8> for ControlFieldType {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, EnumString, PartialEq, Eq, JsonSchema)]
 pub enum SurveillanceStatus {
     NoCondition,
@@ -391,6 +405,18 @@ pub enum SurveillanceStatus {
     SPICondition,
 }
 
+impl SurveillanceStatus {
+    pub fn to_string(&self) -> String {
+        match self {
+            Self::NoCondition => "No condition".to_string(),
+            Self::PermanentAlert => "Permanent alert".to_string(),
+            Self::TemporaryAlert => "Temporary alert".to_string(),
+            Self::SPICondition => "SPI condition".to_string(),
+        }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl SurveillanceStatus {
     pub fn __str__(&self) -> String {
@@ -399,15 +425,6 @@ impl SurveillanceStatus {
 
     pub fn __repr__(&self) -> String {
         self.to_string()
-    }
-
-    pub fn to_string(&self) -> String {
-        match self {
-            Self::NoCondition => "No condition".to_string(),
-            Self::PermanentAlert => "Permanent alert".to_string(),
-            Self::TemporaryAlert => "Temporary alert".to_string(),
-            Self::SPICondition => "SPI condition".to_string(),
-        }
     }
 }
 

--- a/aerosim-data/src/types/adsb/types.rs
+++ b/aerosim-data/src/types/adsb/types.rs
@@ -304,32 +304,34 @@ impl From<u8> for SurveillanceStatus {
 #[cfg(feature = "python")]
 #[pymethods]
 impl ADSB {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("capability", self.capability);
         let _ = dict.set_item("icao", self.icao.to_hex());
-        let _ = dict.set_item("message_extended_quitter", self.me.to_dict(py)?);
+        let _ = dict.set_item("message_extended_quitter", self.me.py_to_dict(py)?);
         let _ = dict.set_item("parity", self.pi.to_hex());
         Ok(dict.into())
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl ME {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         match self {
-            Self::AircraftIdentification(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AirbornePosition(message_type) => Ok(message_type.to_dict(py)?),
-            Self::SurfacePosition(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AirborneVelocity(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AircraftOperationStatusAirborne(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AircraftOperationStatusSurface(message_type) => Ok(message_type.to_dict(py)?),
-            Self::TargetStateAndStatusInformation(message_type) => Ok(message_type.to_dict(py)?),
+            Self::AircraftIdentification(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::AirbornePosition(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::SurfacePosition(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::AirborneVelocity(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::AircraftOperationStatusAirborne(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::AircraftOperationStatusSurface(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::TargetStateAndStatusInformation(message_type) => Ok(message_type.py_to_dict(py)?),
             Self::NoPosition(_) => Ok(py.None()),
             Self::Reserved0(_) => Ok(py.None()),
             Self::Reserved1(_) => Ok(py.None()),
@@ -341,40 +343,42 @@ impl ME {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl ADSBMessageType {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         match self {
-            Self::ShortAirAirSurveillance(message_type) => Ok(message_type.to_dict(py)?),
-            Self::SurveillanceAltitudeReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::SurveillanceIdentityReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::AllCallReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::LongAirAir(message_type) => Ok(message_type.to_dict(py)?),
-            Self::ADSB(message_type) => Ok(message_type.to_dict(py)?),
-            Self::TisB(message_type) => Ok(message_type.to_dict(py)?),
+            Self::ShortAirAirSurveillance(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::SurveillanceAltitudeReply(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::SurveillanceIdentityReply(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::AllCallReply(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::LongAirAir(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::ADSB(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::TisB(message_type) => Ok(message_type.py_to_dict(py)?),
             Self::ExtendedSquitterMilitaryApplication(message_type) => {
-                Ok(message_type.to_dict(py)?)
+                Ok(message_type.py_to_dict(py)?)
             }
-            Self::CommBAltitudeReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::CommBIdentityReply(message_type) => Ok(message_type.to_dict(py)?),
-            Self::GNSSPositionData(message_type) => Ok(message_type.to_dict(py)?),
+            Self::CommBAltitudeReply(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::CommBIdentityReply(message_type) => Ok(message_type.py_to_dict(py)?),
+            Self::GNSSPositionData(message_type) => Ok(message_type.py_to_dict(py)?),
         }
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl CapabilityClassAirborne {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("reserved0", self.reserved0);
         let _ = dict.set_item("acas", self.acas);
@@ -387,14 +391,15 @@ impl CapabilityClassAirborne {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl CapabilityClassSurface {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("reserved0", self.reserved0);
         let _ = dict.set_item("poe", self.poe);
@@ -407,14 +412,15 @@ impl CapabilityClassSurface {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 
 #[cfg(feature = "python")]
 #[pymethods]
 impl OperationalMode {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         let _ = dict.set_item("reserved", self.reserved);
         let _ = dict.set_item("tcas_ra_active", self.tcas_ra_active);
@@ -426,7 +432,7 @@ impl OperationalMode {
     }
 
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
-        self.to_dict(py)
+        self.py_to_dict(py)
     }
 }
 

--- a/aerosim-data/src/types/controller.rs
+++ b/aerosim-data/src/types/controller.rs
@@ -44,43 +44,6 @@ impl AutopilotFlightPlanCommand {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl AutopilotFlightPlanCommand {
-    #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
-        s.parse().map_err(|_| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid AutopilotFlightPlanCommand")
-        })
-    }
-
-    pub fn __str__(&self) -> String {
-        self.to_string()
-    }
-
-    pub fn __repr__(&self) -> String {
-        format!("AutopilotFlightPlanCommand::{}", self)
-    }
-
-    #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        for variant in [
-            AutopilotFlightPlanCommand::Stop,
-            AutopilotFlightPlanCommand::Run,
-            AutopilotFlightPlanCommand::Pause,
-        ] {
-            dict.set_item(variant.to_string(), variant.to_int())?;
-        }
-        Ok(dict.into())
-    }
-
-    #[classattr]
-    fn __type_support__() -> Py<PyCapsule> {
-        PyTypeSupport::create::<Self>()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
 #[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct AutopilotCommand {
@@ -154,6 +117,173 @@ impl AutopilotCommand {
             target_wp_latitude_deg,
             target_wp_longitude_deg,
         }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Flight Control Command
+// Output from (auto)pilot, input to flight controller
+
+#[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct FlightControlCommand {
+    power_cmd: Vec<f64>, // power, 0.0~1.0, array to be able to split vertical lift and horizontal cruise
+    roll_cmd: f64,       // roll axis, -1.0~1.0
+    pitch_cmd: f64,      // pitch axis, -1.0~1.0
+    yaw_cmd: f64,        // yaw axis, -1.0~1.0
+    thrust_tilt_cmd: f64, // tilt vtol, 0.0~1.0
+    flap_cmd: f64,       // flap, 0.0~1.0, for low speed flight
+    speedbrake_cmd: f64, // speedbrake, 0.0~1.0, for fixed-wing
+    landing_gear_cmd: f64, // landing gear, 0.0 up ~ 1.0 down
+    wheel_steer_cmd: f64, // wheel steering, -1.0~1.0
+    wheel_brake_cmd: f64, // wheel brake, 0.0~1.0
+}
+
+impl Default for FlightControlCommand {
+    fn default() -> FlightControlCommand {
+        FlightControlCommand {
+            power_cmd: vec![0.0],
+            roll_cmd: 0.0,
+            pitch_cmd: 0.0,
+            yaw_cmd: 0.0,
+            thrust_tilt_cmd: 0.0,
+            flap_cmd: 0.0,
+            speedbrake_cmd: 0.0,
+            landing_gear_cmd: 0.0,
+            wheel_steer_cmd: 0.0,
+            wheel_brake_cmd: 0.0,
+        }
+    }
+}
+
+impl FlightControlCommand {
+    pub fn new(
+        power_cmd: Vec<f64>,
+        roll_cmd: f64,
+        pitch_cmd: f64,
+        yaw_cmd: f64,
+        thrust_tilt_cmd: f64,
+        flap_cmd: f64,
+        speedbrake_cmd: f64,
+        landing_gear_cmd: f64,
+        wheel_steer_cmd: f64,
+        wheel_brake_cmd: f64,
+    ) -> Self {
+        FlightControlCommand {
+            power_cmd,
+            roll_cmd,
+            pitch_cmd,
+            yaw_cmd,
+            thrust_tilt_cmd,
+            flap_cmd,
+            speedbrake_cmd,
+            landing_gear_cmd,
+            wheel_steer_cmd,
+            wheel_brake_cmd,
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Aircraft Effector Command
+// Output from flight controller, input to flight dynamics model
+
+#[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct AircraftEffectorCommand {
+    throttle_cmd: Vec<f64>,
+    aileron_cmd_angle_rad: Vec<f64>,
+    elevator_cmd_angle_rad: Vec<f64>,
+    rudder_cmd_angle_rad: Vec<f64>,
+    thrust_tilt_cmd_angle_rad: Vec<f64>,
+    flap_cmd_angle_rad: Vec<f64>,
+    speedbrake_cmd_angle_rad: Vec<f64>,
+    landing_gear_cmd: Vec<f64>,
+    wheel_steer_cmd_angle_rad: Vec<f64>,
+    wheel_brake_cmd: Vec<f64>,
+}
+
+impl Default for AircraftEffectorCommand {
+    fn default() -> AircraftEffectorCommand {
+        AircraftEffectorCommand {
+            throttle_cmd: vec![],
+            aileron_cmd_angle_rad: vec![],
+            elevator_cmd_angle_rad: vec![],
+            rudder_cmd_angle_rad: vec![],
+            thrust_tilt_cmd_angle_rad: vec![],
+            flap_cmd_angle_rad: vec![],
+            speedbrake_cmd_angle_rad: vec![],
+            landing_gear_cmd: vec![],
+            wheel_steer_cmd_angle_rad: vec![],
+            wheel_brake_cmd: vec![],
+        }
+    }
+}
+
+impl AircraftEffectorCommand {
+    pub fn new(
+        throttle_cmd: Vec<f64>,
+        aileron_cmd_angle_rad: Vec<f64>,
+        elevator_cmd_angle_rad: Vec<f64>,
+        rudder_cmd_angle_rad: Vec<f64>,
+        thrust_tilt_cmd_angle_rad: Vec<f64>,
+        flap_cmd_angle_rad: Vec<f64>,
+        speedbrake_cmd_angle_rad: Vec<f64>,
+        landing_gear_cmd: Vec<f64>,
+        wheel_steer_cmd_angle_rad: Vec<f64>,
+        wheel_brake_cmd: Vec<f64>,
+    ) -> Self {
+        AircraftEffectorCommand {
+            throttle_cmd,
+            aileron_cmd_angle_rad,
+            elevator_cmd_angle_rad,
+            rudder_cmd_angle_rad,
+            thrust_tilt_cmd_angle_rad,
+            flap_cmd_angle_rad,
+            speedbrake_cmd_angle_rad,
+            landing_gear_cmd,
+            wheel_steer_cmd_angle_rad,
+            wheel_brake_cmd,
+        }
+    }
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl AutopilotFlightPlanCommand {
+    #[staticmethod]
+    pub fn from_str(s: &str) -> PyResult<Self> {
+        s.parse().map_err(|_| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid AutopilotFlightPlanCommand")
+        })
+    }
+
+    pub fn __str__(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("AutopilotFlightPlanCommand::{}", self)
+    }
+
+    #[staticmethod]
+    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+        let dict = pyo3::types::PyDict::new(py);
+        for variant in [
+            AutopilotFlightPlanCommand::Stop,
+            AutopilotFlightPlanCommand::Run,
+            AutopilotFlightPlanCommand::Pause,
+        ] {
+            dict.set_item(variant.to_string(), variant.to_int())?;
+        }
+        Ok(dict.into())
+    }
+
+    #[classattr]
+    fn __type_support__() -> Py<PyCapsule> {
+        PyTypeSupport::create::<Self>()
     }
 }
 
@@ -232,70 +362,6 @@ impl AutopilotCommand {
     }
 }
 
-// ----------------------------------------------------------------------------
-// Flight Control Command
-// Output from (auto)pilot, input to flight controller
-
-#[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct FlightControlCommand {
-    power_cmd: Vec<f64>, // power, 0.0~1.0, array to be able to split vertical lift and horizontal cruise
-    roll_cmd: f64,       // roll axis, -1.0~1.0
-    pitch_cmd: f64,      // pitch axis, -1.0~1.0
-    yaw_cmd: f64,        // yaw axis, -1.0~1.0
-    thrust_tilt_cmd: f64, // tilt vtol, 0.0~1.0
-    flap_cmd: f64,       // flap, 0.0~1.0, for low speed flight
-    speedbrake_cmd: f64, // speedbrake, 0.0~1.0, for fixed-wing
-    landing_gear_cmd: f64, // landing gear, 0.0 up ~ 1.0 down
-    wheel_steer_cmd: f64, // wheel steering, -1.0~1.0
-    wheel_brake_cmd: f64, // wheel brake, 0.0~1.0
-}
-
-impl Default for FlightControlCommand {
-    fn default() -> FlightControlCommand {
-        FlightControlCommand {
-            power_cmd: vec![0.0],
-            roll_cmd: 0.0,
-            pitch_cmd: 0.0,
-            yaw_cmd: 0.0,
-            thrust_tilt_cmd: 0.0,
-            flap_cmd: 0.0,
-            speedbrake_cmd: 0.0,
-            landing_gear_cmd: 0.0,
-            wheel_steer_cmd: 0.0,
-            wheel_brake_cmd: 0.0,
-        }
-    }
-}
-
-impl FlightControlCommand {
-    pub fn new(
-        power_cmd: Vec<f64>,
-        roll_cmd: f64,
-        pitch_cmd: f64,
-        yaw_cmd: f64,
-        thrust_tilt_cmd: f64,
-        flap_cmd: f64,
-        speedbrake_cmd: f64,
-        landing_gear_cmd: f64,
-        wheel_steer_cmd: f64,
-        wheel_brake_cmd: f64,
-    ) -> Self {
-        FlightControlCommand {
-            power_cmd,
-            roll_cmd,
-            pitch_cmd,
-            yaw_cmd,
-            thrust_tilt_cmd,
-            flap_cmd,
-            speedbrake_cmd,
-            landing_gear_cmd,
-            wheel_steer_cmd,
-            wheel_brake_cmd,
-        }
-    }
-}
-
 #[cfg(feature = "python")]
 #[pymethods]
 impl FlightControlCommand {
@@ -355,70 +421,6 @@ impl FlightControlCommand {
     #[classattr]
     fn __type_support__() -> Py<PyCapsule> {
         PyTypeSupport::create::<Self>()
-    }
-}
-
-// ----------------------------------------------------------------------------
-// Aircraft Effector Command
-// Output from flight controller, input to flight dynamics model
-
-#[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct AircraftEffectorCommand {
-    throttle_cmd: Vec<f64>,
-    aileron_cmd_angle_rad: Vec<f64>,
-    elevator_cmd_angle_rad: Vec<f64>,
-    rudder_cmd_angle_rad: Vec<f64>,
-    thrust_tilt_cmd_angle_rad: Vec<f64>,
-    flap_cmd_angle_rad: Vec<f64>,
-    speedbrake_cmd_angle_rad: Vec<f64>,
-    landing_gear_cmd: Vec<f64>,
-    wheel_steer_cmd_angle_rad: Vec<f64>,
-    wheel_brake_cmd: Vec<f64>,
-}
-
-impl Default for AircraftEffectorCommand {
-    fn default() -> AircraftEffectorCommand {
-        AircraftEffectorCommand {
-            throttle_cmd: vec![],
-            aileron_cmd_angle_rad: vec![],
-            elevator_cmd_angle_rad: vec![],
-            rudder_cmd_angle_rad: vec![],
-            thrust_tilt_cmd_angle_rad: vec![],
-            flap_cmd_angle_rad: vec![],
-            speedbrake_cmd_angle_rad: vec![],
-            landing_gear_cmd: vec![],
-            wheel_steer_cmd_angle_rad: vec![],
-            wheel_brake_cmd: vec![],
-        }
-    }
-}
-
-impl AircraftEffectorCommand {
-    pub fn new(
-        throttle_cmd: Vec<f64>,
-        aileron_cmd_angle_rad: Vec<f64>,
-        elevator_cmd_angle_rad: Vec<f64>,
-        rudder_cmd_angle_rad: Vec<f64>,
-        thrust_tilt_cmd_angle_rad: Vec<f64>,
-        flap_cmd_angle_rad: Vec<f64>,
-        speedbrake_cmd_angle_rad: Vec<f64>,
-        landing_gear_cmd: Vec<f64>,
-        wheel_steer_cmd_angle_rad: Vec<f64>,
-        wheel_brake_cmd: Vec<f64>,
-    ) -> Self {
-        AircraftEffectorCommand {
-            throttle_cmd,
-            aileron_cmd_angle_rad,
-            elevator_cmd_angle_rad,
-            rudder_cmd_angle_rad,
-            thrust_tilt_cmd_angle_rad,
-            flap_cmd_angle_rad,
-            speedbrake_cmd_angle_rad,
-            landing_gear_cmd,
-            wheel_steer_cmd_angle_rad,
-            wheel_brake_cmd,
-        }
     }
 }
 

--- a/aerosim-data/src/types/controller.rs
+++ b/aerosim-data/src/types/controller.rs
@@ -1,13 +1,18 @@
-use pyo3::{
-    prelude::*,
-    types::{PyCapsule, PyDict, PyList},
-};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use strum_macros::{Display, EnumString};
 
-use crate::{types::PyTypeSupport, AerosimMessage};
+use crate::AerosimMessage;
+
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict, PyList},
+    },
+};
 
 // ----------------------------------------------------------------------------
 // Autopilot Flight Plan State
@@ -26,13 +31,20 @@ use crate::{types::PyTypeSupport, AerosimMessage};
     JsonSchema,
 )]
 #[repr(u8)]
-#[pyclass(eq, eq_int, get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int, get_all, set_all))]
 pub enum AutopilotFlightPlanCommand {
     Stop = 0,
     Run = 1,
     Pause = 2,
 }
 
+impl AutopilotFlightPlanCommand {
+    pub fn to_int(&self) -> i32 {
+        *self as i32
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl AutopilotFlightPlanCommand {
     #[staticmethod]
@@ -48,10 +60,6 @@ impl AutopilotFlightPlanCommand {
 
     pub fn __repr__(&self) -> String {
         format!("AutopilotFlightPlanCommand::{}", self)
-    }
-
-    pub fn to_int(&self) -> i32 {
-        *self as i32
     }
 
     #[staticmethod]
@@ -74,7 +82,7 @@ impl AutopilotFlightPlanCommand {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct AutopilotCommand {
     pub flight_plan: String, // some kind of flight plan, e.g. waypoints, mission, etc. (JSON?)
     pub flight_plan_command: AutopilotFlightPlanCommand, // flight plan execution command
@@ -115,24 +123,7 @@ impl Default for AutopilotCommand {
 // Autopilot Command
 // Input to autopilot
 
-#[pymethods]
 impl AutopilotCommand {
-    #[new]
-    #[pyo3(signature = (
-        flight_plan=AutopilotCommand::default().flight_plan,
-        flight_plan_command=AutopilotCommand::default().flight_plan_command,
-        use_manual_setpoints=AutopilotCommand::default().use_manual_setpoints,
-        attitude_hold=AutopilotCommand::default().attitude_hold,
-        altitude_hold=AutopilotCommand::default().altitude_hold,
-        altitude_setpoint_ft=AutopilotCommand::default().altitude_setpoint_ft,
-        airspeed_hold=AutopilotCommand::default().airspeed_hold,
-        airspeed_setpoint_kts=AutopilotCommand::default().airspeed_setpoint_kts,
-        heading_hold=AutopilotCommand::default().heading_hold,
-        heading_set_by_waypoint=AutopilotCommand::default().heading_set_by_waypoint,
-        heading_setpoint_deg=AutopilotCommand::default().heading_setpoint_deg,
-        target_wp_latitude_deg=AutopilotCommand::default().target_wp_latitude_deg,
-        target_wp_longitude_deg=AutopilotCommand::default().target_wp_longitude_deg
-    ))]
     pub fn new(
         flight_plan: String,
         flight_plan_command: AutopilotFlightPlanCommand,
@@ -164,6 +155,58 @@ impl AutopilotCommand {
             target_wp_longitude_deg,
         }
     }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl AutopilotCommand {
+    #[new]
+    #[pyo3(signature = (
+        flight_plan=AutopilotCommand::default().flight_plan,
+        flight_plan_command=AutopilotCommand::default().flight_plan_command,
+        use_manual_setpoints=AutopilotCommand::default().use_manual_setpoints,
+        attitude_hold=AutopilotCommand::default().attitude_hold,
+        altitude_hold=AutopilotCommand::default().altitude_hold,
+        altitude_setpoint_ft=AutopilotCommand::default().altitude_setpoint_ft,
+        airspeed_hold=AutopilotCommand::default().airspeed_hold,
+        airspeed_setpoint_kts=AutopilotCommand::default().airspeed_setpoint_kts,
+        heading_hold=AutopilotCommand::default().heading_hold,
+        heading_set_by_waypoint=AutopilotCommand::default().heading_set_by_waypoint,
+        heading_setpoint_deg=AutopilotCommand::default().heading_setpoint_deg,
+        target_wp_latitude_deg=AutopilotCommand::default().target_wp_latitude_deg,
+        target_wp_longitude_deg=AutopilotCommand::default().target_wp_longitude_deg
+    ))]
+    fn py_new(
+        flight_plan: String,
+        flight_plan_command: AutopilotFlightPlanCommand,
+        use_manual_setpoints: bool,
+        attitude_hold: bool,
+        altitude_hold: bool,
+        altitude_setpoint_ft: f64,
+        airspeed_hold: bool,
+        airspeed_setpoint_kts: f64,
+        heading_hold: bool,
+        heading_set_by_waypoint: bool,
+        heading_setpoint_deg: f64,
+        target_wp_latitude_deg: f64,
+        target_wp_longitude_deg: f64,
+    ) -> Self {
+        Self::new(
+            flight_plan,
+            flight_plan_command,
+            use_manual_setpoints,
+            attitude_hold,
+            altitude_hold,
+            altitude_setpoint_ft,
+            airspeed_hold,
+            airspeed_setpoint_kts,
+            heading_hold,
+            heading_set_by_waypoint,
+            heading_setpoint_deg,
+            target_wp_latitude_deg,
+            target_wp_longitude_deg,
+        )
+    }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -194,7 +237,7 @@ impl AutopilotCommand {
 // Output from (auto)pilot, input to flight controller
 
 #[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct FlightControlCommand {
     power_cmd: Vec<f64>, // power, 0.0~1.0, array to be able to split vertical lift and horizontal cruise
     roll_cmd: f64,       // roll axis, -1.0~1.0
@@ -225,20 +268,7 @@ impl Default for FlightControlCommand {
     }
 }
 
-#[pymethods]
 impl FlightControlCommand {
-    #[new]
-    #[pyo3(signature = (
-        power_cmd=FlightControlCommand::default().power_cmd,
-        roll_cmd=FlightControlCommand::default().roll_cmd,
-        pitch_cmd=FlightControlCommand::default().pitch_cmd,
-        yaw_cmd=FlightControlCommand::default().yaw_cmd,
-        thrust_tilt_cmd=FlightControlCommand::default().thrust_tilt_cmd,
-        flap_cmd=FlightControlCommand::default().flap_cmd,
-        speedbrake_cmd=FlightControlCommand::default().speedbrake_cmd,
-        landing_gear_cmd=FlightControlCommand::default().landing_gear_cmd,
-        wheel_steer_cmd=FlightControlCommand::default().wheel_steer_cmd,
-        wheel_brake_cmd=FlightControlCommand::default().wheel_brake_cmd))]
     pub fn new(
         power_cmd: Vec<f64>,
         roll_cmd: f64,
@@ -263,6 +293,48 @@ impl FlightControlCommand {
             wheel_steer_cmd,
             wheel_brake_cmd,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl FlightControlCommand {
+    #[new]
+    #[pyo3(signature = (
+        power_cmd=FlightControlCommand::default().power_cmd,
+        roll_cmd=FlightControlCommand::default().roll_cmd,
+        pitch_cmd=FlightControlCommand::default().pitch_cmd,
+        yaw_cmd=FlightControlCommand::default().yaw_cmd,
+        thrust_tilt_cmd=FlightControlCommand::default().thrust_tilt_cmd,
+        flap_cmd=FlightControlCommand::default().flap_cmd,
+        speedbrake_cmd=FlightControlCommand::default().speedbrake_cmd,
+        landing_gear_cmd=FlightControlCommand::default().landing_gear_cmd,
+        wheel_steer_cmd=FlightControlCommand::default().wheel_steer_cmd,
+        wheel_brake_cmd=FlightControlCommand::default().wheel_brake_cmd))]
+    fn py_new(
+        power_cmd: Vec<f64>,
+        roll_cmd: f64,
+        pitch_cmd: f64,
+        yaw_cmd: f64,
+        thrust_tilt_cmd: f64,
+        flap_cmd: f64,
+        speedbrake_cmd: f64,
+        landing_gear_cmd: f64,
+        wheel_steer_cmd: f64,
+        wheel_brake_cmd: f64,
+    ) -> Self {
+        Self::new(
+            power_cmd,
+            roll_cmd,
+            pitch_cmd,
+            yaw_cmd,
+            thrust_tilt_cmd,
+            flap_cmd,
+            speedbrake_cmd,
+            landing_gear_cmd,
+            wheel_steer_cmd,
+            wheel_brake_cmd,
+        )
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -291,7 +363,7 @@ impl FlightControlCommand {
 // Output from flight controller, input to flight dynamics model
 
 #[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct AircraftEffectorCommand {
     throttle_cmd: Vec<f64>,
     aileron_cmd_angle_rad: Vec<f64>,
@@ -322,21 +394,7 @@ impl Default for AircraftEffectorCommand {
     }
 }
 
-#[pymethods]
 impl AircraftEffectorCommand {
-    #[new]
-    #[pyo3(signature = (
-        throttle_cmd=AircraftEffectorCommand::default().throttle_cmd,
-        aileron_cmd_angle_rad=AircraftEffectorCommand::default().aileron_cmd_angle_rad,
-        elevator_cmd_angle_rad=AircraftEffectorCommand::default().elevator_cmd_angle_rad,
-        rudder_cmd_angle_rad=AircraftEffectorCommand::default().rudder_cmd_angle_rad,
-        thrust_tilt_cmd_angle_rad=AircraftEffectorCommand::default().thrust_tilt_cmd_angle_rad,
-        flap_cmd_angle_rad=AircraftEffectorCommand::default().flap_cmd_angle_rad,
-        speedbrake_cmd_angle_rad=AircraftEffectorCommand::default().speedbrake_cmd_angle_rad,
-        landing_gear_cmd=AircraftEffectorCommand::default().landing_gear_cmd,
-        wheel_steer_cmd_angle_rad=AircraftEffectorCommand::default().wheel_steer_cmd_angle_rad,
-        wheel_brake_cmd=AircraftEffectorCommand::default().wheel_brake_cmd
-    ))]
     pub fn new(
         throttle_cmd: Vec<f64>,
         aileron_cmd_angle_rad: Vec<f64>,
@@ -361,6 +419,49 @@ impl AircraftEffectorCommand {
             wheel_steer_cmd_angle_rad,
             wheel_brake_cmd,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl AircraftEffectorCommand {
+    #[new]
+    #[pyo3(signature = (
+        throttle_cmd=AircraftEffectorCommand::default().throttle_cmd,
+        aileron_cmd_angle_rad=AircraftEffectorCommand::default().aileron_cmd_angle_rad,
+        elevator_cmd_angle_rad=AircraftEffectorCommand::default().elevator_cmd_angle_rad,
+        rudder_cmd_angle_rad=AircraftEffectorCommand::default().rudder_cmd_angle_rad,
+        thrust_tilt_cmd_angle_rad=AircraftEffectorCommand::default().thrust_tilt_cmd_angle_rad,
+        flap_cmd_angle_rad=AircraftEffectorCommand::default().flap_cmd_angle_rad,
+        speedbrake_cmd_angle_rad=AircraftEffectorCommand::default().speedbrake_cmd_angle_rad,
+        landing_gear_cmd=AircraftEffectorCommand::default().landing_gear_cmd,
+        wheel_steer_cmd_angle_rad=AircraftEffectorCommand::default().wheel_steer_cmd_angle_rad,
+        wheel_brake_cmd=AircraftEffectorCommand::default().wheel_brake_cmd
+    ))]
+    fn py_new(
+        throttle_cmd: Vec<f64>,
+        aileron_cmd_angle_rad: Vec<f64>,
+        elevator_cmd_angle_rad: Vec<f64>,
+        rudder_cmd_angle_rad: Vec<f64>,
+        thrust_tilt_cmd_angle_rad: Vec<f64>,
+        flap_cmd_angle_rad: Vec<f64>,
+        speedbrake_cmd_angle_rad: Vec<f64>,
+        landing_gear_cmd: Vec<f64>,
+        wheel_steer_cmd_angle_rad: Vec<f64>,
+        wheel_brake_cmd: Vec<f64>,
+    ) -> Self {
+        Self::new(
+            throttle_cmd,
+            aileron_cmd_angle_rad,
+            elevator_cmd_angle_rad,
+            rudder_cmd_angle_rad,
+            thrust_tilt_cmd_angle_rad,
+            flap_cmd_angle_rad,
+            speedbrake_cmd_angle_rad,
+            landing_gear_cmd,
+            wheel_steer_cmd_angle_rad,
+            wheel_brake_cmd,
+        )
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/controller.rs
+++ b/aerosim-data/src/types/controller.rs
@@ -254,7 +254,8 @@ impl AircraftEffectorCommand {
 #[pymethods]
 impl AutopilotFlightPlanCommand {
     #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
+    #[pyo3(name = "from_str")]
+    pub fn py_from_str(s: &str) -> PyResult<Self> {
         s.parse().map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid AutopilotFlightPlanCommand")
         })
@@ -269,7 +270,8 @@ impl AutopilotFlightPlanCommand {
     }
 
     #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(py: Python) -> PyResult<PyObject> {
         let dict = pyo3::types::PyDict::new(py);
         for variant in [
             AutopilotFlightPlanCommand::Stop,
@@ -338,7 +340,8 @@ impl AutopilotCommand {
         )
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("flight_plan", &self.flight_plan)?;
         dict.set_item("flight_plan_command", &self.flight_plan_command.to_int())?;
@@ -403,7 +406,8 @@ impl FlightControlCommand {
         )
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("power_cmd", PyList::new(py, &self.power_cmd)?.as_ref())?;
         dict.set_item("roll_cmd", self.roll_cmd)?;
@@ -466,7 +470,8 @@ impl AircraftEffectorCommand {
         )
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item(
             "throttle_cmd",

--- a/aerosim-data/src/types/downlink_format/all_call.rs
+++ b/aerosim-data/src/types/downlink_format/all_call.rs
@@ -24,7 +24,8 @@ impl AllCallReply {
         Ok(dict.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 }

--- a/aerosim-data/src/types/downlink_format/all_call.rs
+++ b/aerosim-data/src/types/downlink_format/all_call.rs
@@ -1,16 +1,18 @@
+#[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::adsb::types::{Capability, ICAOAddress};
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct AllCallReply {
     pub icao: ICAOAddress,
     pub capability: Capability,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl AllCallReply {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/all_call.rs
+++ b/aerosim-data/src/types/downlink_format/all_call.rs
@@ -12,6 +12,8 @@ pub struct AllCallReply {
     pub capability: Capability,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl AllCallReply {

--- a/aerosim-data/src/types/downlink_format/bds.rs
+++ b/aerosim-data/src/types/downlink_format/bds.rs
@@ -36,7 +36,8 @@ pub struct DataLinkCapability {
 #[cfg(feature = "python")]
 #[pymethods]
 impl BDS {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 
@@ -52,7 +53,7 @@ impl BDS {
             }
             Self::DataLinkCapability(dlc) => {
                 let _ = dict.set_item("type", "datalink_capability");
-                let _ = dict.set_item("datalink_capability", dlc.to_dict(py)?);
+                let _ = dict.set_item("datalink_capability", dlc.py_to_dict(py)?);
             }
             Self::Unknown() => {
                 let _ = dict.set_item("type", "unknown");
@@ -65,7 +66,8 @@ impl BDS {
 #[cfg(feature = "python")]
 #[pymethods]
 impl DataLinkCapability {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 

--- a/aerosim-data/src/types/downlink_format/bds.rs
+++ b/aerosim-data/src/types/downlink_format/bds.rs
@@ -31,6 +31,8 @@ pub struct DataLinkCapability {
     pub bit_array: u16,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl BDS {

--- a/aerosim-data/src/types/downlink_format/bds.rs
+++ b/aerosim-data/src/types/downlink_format/bds.rs
@@ -1,8 +1,9 @@
+#[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[pyclass(eq)]
+#[cfg_attr(feature = "python", pyclass(eq))]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum BDS {
     Empty(),
@@ -11,7 +12,7 @@ pub enum BDS {
     Unknown(),
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct DataLinkCapability {
     pub continuation_flag: bool,
@@ -30,6 +31,7 @@ pub struct DataLinkCapability {
     pub bit_array: u16,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl BDS {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -58,6 +60,7 @@ impl BDS {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl DataLinkCapability {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/comm.rs
+++ b/aerosim-data/src/types/downlink_format/comm.rs
@@ -39,7 +39,8 @@ pub struct CommDExtendedLengthMessage {
 #[cfg(feature = "python")]
 #[pymethods]
 impl CommBAltitudeReply {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 
@@ -47,7 +48,7 @@ impl CommBAltitudeReply {
         let dict = PyDict::new(py);
         let _ = dict.set_item("icao", self.icao.to_hex());
         let _ = dict.set_item("altitude", self.altitude);
-        let _ = dict.set_item("bds", self.bds.to_dict(py)?);
+        let _ = dict.set_item("bds", self.bds.py_to_dict(py)?);
         Ok(dict.into())
     }
 }
@@ -55,7 +56,8 @@ impl CommBAltitudeReply {
 #[cfg(feature = "python")]
 #[pymethods]
 impl CommBIdentityReply {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 
@@ -63,7 +65,7 @@ impl CommBIdentityReply {
         let dict = PyDict::new(py);
         let _ = dict.set_item("icao", self.icao.to_hex());
         let _ = dict.set_item("squawk", self.squawk);
-        let _ = dict.set_item("bds", self.bds.to_dict(py)?);
+        let _ = dict.set_item("bds", self.bds.py_to_dict(py)?);
         Ok(dict.into())
     }
 }
@@ -71,7 +73,8 @@ impl CommBIdentityReply {
 #[cfg(feature = "python")]
 #[pymethods]
 impl CommDExtendedLengthMessage {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 
@@ -85,7 +88,8 @@ impl CommDExtendedLengthMessage {
 #[cfg(feature = "python")]
 #[pymethods]
 impl ExtendedSquitterMilitaryApplication {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 

--- a/aerosim-data/src/types/downlink_format/comm.rs
+++ b/aerosim-data/src/types/downlink_format/comm.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -5,13 +6,13 @@ use serde::{Deserialize, Serialize};
 use crate::types::adsb::types::ICAOAddress;
 use crate::types::downlink_format::bds::BDS;
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ExtendedSquitterMilitaryApplication {
     pub reserved: u8,
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CommBAltitudeReply {
     pub icao: ICAOAddress,
@@ -19,7 +20,7 @@ pub struct CommBAltitudeReply {
     pub bds: BDS,
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CommBIdentityReply {
     pub icao: ICAOAddress,
@@ -27,12 +28,13 @@ pub struct CommBIdentityReply {
     pub bds: BDS,
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CommDExtendedLengthMessage {
     pub icao: ICAOAddress,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl CommBAltitudeReply {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -48,6 +50,7 @@ impl CommBAltitudeReply {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl CommBIdentityReply {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -63,6 +66,7 @@ impl CommBIdentityReply {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl CommDExtendedLengthMessage {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -76,6 +80,7 @@ impl CommDExtendedLengthMessage {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl ExtendedSquitterMilitaryApplication {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/comm.rs
+++ b/aerosim-data/src/types/downlink_format/comm.rs
@@ -34,6 +34,8 @@ pub struct CommDExtendedLengthMessage {
     pub icao: ICAOAddress,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl CommBAltitudeReply {

--- a/aerosim-data/src/types/downlink_format/long_air_air.rs
+++ b/aerosim-data/src/types/downlink_format/long_air_air.rs
@@ -12,6 +12,8 @@ pub struct LongAirAir {
     pub altitude: u16,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl LongAirAir {

--- a/aerosim-data/src/types/downlink_format/long_air_air.rs
+++ b/aerosim-data/src/types/downlink_format/long_air_air.rs
@@ -24,7 +24,8 @@ impl LongAirAir {
         Ok(dict.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 }

--- a/aerosim-data/src/types/downlink_format/long_air_air.rs
+++ b/aerosim-data/src/types/downlink_format/long_air_air.rs
@@ -1,16 +1,18 @@
+#[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::adsb::types::ICAOAddress;
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct LongAirAir {
     pub icao: ICAOAddress,
     pub altitude: u16,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl LongAirAir {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/mod.rs
+++ b/aerosim-data/src/types/downlink_format/mod.rs
@@ -30,6 +30,8 @@ pub enum DownlinkFormat {
     CommDExtendedLength(comm::CommDExtendedLengthMessage),
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl DownlinkFormat {

--- a/aerosim-data/src/types/downlink_format/mod.rs
+++ b/aerosim-data/src/types/downlink_format/mod.rs
@@ -35,20 +35,21 @@ pub enum DownlinkFormat {
 #[cfg(feature = "python")]
 #[pymethods]
 impl DownlinkFormat {
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         match self {
-            DownlinkFormat::ShortAirAir(s) => s.to_dict(py),
-            DownlinkFormat::SurveillanceAltitude(s) => s.to_dict(py),
-            DownlinkFormat::SurveillanceIdentity(s) => s.to_dict(py),
-            DownlinkFormat::AllCall(s) => s.to_dict(py),
-            DownlinkFormat::LongAirAir(s) => s.to_dict(py),
-            DownlinkFormat::ADSB(s) => s.to_dict(py),
-            DownlinkFormat::TisB(s) => s.to_dict(py),
-            DownlinkFormat::ExtendedSquitterMilitaryApplication(s) => s.to_dict(py),
-            DownlinkFormat::CommBAltitude(s) => s.to_dict(py),
-            DownlinkFormat::CommBIdentity(s) => s.to_dict(py),
-            DownlinkFormat::CommDExtendedLength(s) => s.to_dict(py),
-            DownlinkFormat::GNSSPositionData(s) => s.to_dict(py),
+            DownlinkFormat::ShortAirAir(s) => s.py_to_dict(py),
+            DownlinkFormat::SurveillanceAltitude(s) => s.py_to_dict(py),
+            DownlinkFormat::SurveillanceIdentity(s) => s.py_to_dict(py),
+            DownlinkFormat::AllCall(s) => s.py_to_dict(py),
+            DownlinkFormat::LongAirAir(s) => s.py_to_dict(py),
+            DownlinkFormat::ADSB(s) => s.py_to_dict(py),
+            DownlinkFormat::TisB(s) => s.py_to_dict(py),
+            DownlinkFormat::ExtendedSquitterMilitaryApplication(s) => s.py_to_dict(py),
+            DownlinkFormat::CommBAltitude(s) => s.py_to_dict(py),
+            DownlinkFormat::CommBIdentity(s) => s.py_to_dict(py),
+            DownlinkFormat::CommDExtendedLength(s) => s.py_to_dict(py),
+            DownlinkFormat::GNSSPositionData(s) => s.py_to_dict(py),
         }
     }
 }

--- a/aerosim-data/src/types/downlink_format/mod.rs
+++ b/aerosim-data/src/types/downlink_format/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,7 +12,7 @@ pub mod long_air_air;
 pub mod surveillance;
 pub mod tisb;
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum DownlinkFormat {
@@ -29,6 +30,7 @@ pub enum DownlinkFormat {
     CommDExtendedLength(comm::CommDExtendedLengthMessage),
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl DownlinkFormat {
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/surveillance.rs
+++ b/aerosim-data/src/types/downlink_format/surveillance.rs
@@ -40,7 +40,8 @@ impl ShortAirAirSurveillance {
         Ok(dict.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 }
@@ -56,7 +57,8 @@ impl SurveillanceAltitudeReply {
         Ok(dict.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 }
@@ -72,7 +74,8 @@ impl SurveillanceIdentityReply {
         Ok(dict.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 }

--- a/aerosim-data/src/types/downlink_format/surveillance.rs
+++ b/aerosim-data/src/types/downlink_format/surveillance.rs
@@ -1,17 +1,18 @@
+#[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::adsb::types::{FlightStatus, ICAOAddress};
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ShortAirAirSurveillance {
     pub icao: ICAOAddress,
     pub altitude: u16,
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SurveillanceAltitudeReply {
     pub icao: ICAOAddress,
@@ -19,7 +20,7 @@ pub struct SurveillanceAltitudeReply {
     pub flight_status: FlightStatus,
 }
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SurveillanceIdentityReply {
     pub icao: ICAOAddress,
@@ -27,6 +28,7 @@ pub struct SurveillanceIdentityReply {
     pub flight_status: FlightStatus,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl ShortAirAirSurveillance {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
@@ -41,6 +43,7 @@ impl ShortAirAirSurveillance {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl SurveillanceAltitudeReply {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {
@@ -56,6 +59,7 @@ impl SurveillanceAltitudeReply {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl SurveillanceIdentityReply {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/surveillance.rs
+++ b/aerosim-data/src/types/downlink_format/surveillance.rs
@@ -28,6 +28,8 @@ pub struct SurveillanceIdentityReply {
     pub flight_status: FlightStatus,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl ShortAirAirSurveillance {

--- a/aerosim-data/src/types/downlink_format/tisb.rs
+++ b/aerosim-data/src/types/downlink_format/tisb.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "python")]
 use pyo3::{prelude::*, types::PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::adsb::types::{ControlFieldType, ICAOAddress, ME};
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TisB {
     pub control_type: ControlFieldType,
@@ -12,6 +13,7 @@ pub struct TisB {
     pub me: ME,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl TisB {
     pub fn __dict__(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/downlink_format/tisb.rs
+++ b/aerosim-data/src/types/downlink_format/tisb.rs
@@ -13,6 +13,8 @@ pub struct TisB {
     pub me: ME,
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl TisB {

--- a/aerosim-data/src/types/downlink_format/tisb.rs
+++ b/aerosim-data/src/types/downlink_format/tisb.rs
@@ -22,11 +22,12 @@ impl TisB {
         let dict = PyDict::new(py);
         let _ = dict.set_item("address_announced", self.aa.to_hex());
         let _ = dict.set_item("control_type", self.control_type);
-        let _ = dict.set_item("message_extended_squitter", self.me.to_dict(py)?);
+        let _ = dict.set_item("message_extended_squitter", self.me.py_to_dict(py)?);
         Ok(dict.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         self.__dict__(py)
     }
 }

--- a/aerosim-data/src/types/effector.rs
+++ b/aerosim-data/src/types/effector.rs
@@ -1,23 +1,37 @@
 use crate::types::geometry::Pose;
-use crate::{types::PyTypeSupport, AerosimMessage};
+use crate::AerosimMessage;
 
-use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct EffectorState {
     pub pose: Pose,
 }
 
+impl EffectorState {
+    pub fn new(pose: Pose) -> Self {
+        EffectorState { pose }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl EffectorState {
     #[new]
     #[pyo3(signature = (pose=Pose::default()))]
-    pub fn new(pose: Pose) -> Self {
-        EffectorState { pose }
+    fn py_new(pose: Pose) -> Self {
+        Self::new(pose)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/effector.rs
+++ b/aerosim-data/src/types/effector.rs
@@ -25,6 +25,8 @@ impl EffectorState {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl EffectorState {

--- a/aerosim-data/src/types/effector.rs
+++ b/aerosim-data/src/types/effector.rs
@@ -36,9 +36,10 @@ impl EffectorState {
         Self::new(pose)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("pose", self.pose.to_dict(py)?)?;
+        dict.set_item("pose", self.pose.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 

--- a/aerosim-data/src/types/flight_deck.rs
+++ b/aerosim-data/src/types/flight_deck.rs
@@ -1,11 +1,18 @@
-use crate::{types::PyTypeSupport, AerosimMessage};
+use crate::AerosimMessage;
 
-use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use strum_macros::{Display, EnumString};
+
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
 
 #[derive(
     Debug,
@@ -20,13 +27,20 @@ use strum_macros::{Display, EnumString};
     JsonSchema,
 )]
 #[repr(u8)]
-#[pyclass(eq, eq_int, get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int, get_all, set_all))]
 pub enum HSIMode {
     GPS = 0,
     VOR1 = 1,
     VOR2 = 2,
 }
 
+impl HSIMode {
+    pub fn to_int(&self) -> i32 {
+        *self as i32
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl HSIMode {
     pub fn __str__(&self) -> String {
@@ -37,8 +51,9 @@ impl HSIMode {
         format!("HSIMode::{}", self)
     }
 
-    pub fn to_int(&self) -> i32 {
-        *self as i32
+    #[pyo3(name = "to_int")]
+    fn py_to_int(&self) -> i32 {
+        self.to_int()
     }
 
     #[staticmethod]
@@ -57,7 +72,7 @@ impl HSIMode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct PrimaryFlightDisplayData {
     pub airspeed_kts: f64,                    // JSBSim "velocities/vc-kts"
     pub true_airspeed_kts: f64,               // JSBSim "velocities/vtrue-kts"
@@ -94,11 +109,18 @@ impl Default for PrimaryFlightDisplayData {
     }
 }
 
+impl PrimaryFlightDisplayData {
+    pub fn new() -> Self {
+        PrimaryFlightDisplayData::default()
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl PrimaryFlightDisplayData {
     #[new]
-    pub fn new() -> Self {
-        PrimaryFlightDisplayData::default()
+    fn py_new() -> Self {
+        Self::new()
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/flight_deck.rs
+++ b/aerosim-data/src/types/flight_deck.rs
@@ -40,37 +40,6 @@ impl HSIMode {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl HSIMode {
-    pub fn __str__(&self) -> String {
-        self.to_string()
-    }
-
-    pub fn __repr__(&self) -> String {
-        format!("HSIMode::{}", self)
-    }
-
-    #[pyo3(name = "to_int")]
-    fn py_to_int(&self) -> i32 {
-        self.to_int()
-    }
-
-    #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        for variant in [HSIMode::GPS, HSIMode::VOR1, HSIMode::VOR2] {
-            dict.set_item(variant.to_string(), variant.to_int())?;
-        }
-        Ok(dict.into())
-    }
-
-    #[classattr]
-    fn __type_support__() -> Py<PyCapsule> {
-        PyTypeSupport::create::<Self>()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
 #[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct PrimaryFlightDisplayData {
@@ -112,6 +81,39 @@ impl Default for PrimaryFlightDisplayData {
 impl PrimaryFlightDisplayData {
     pub fn new() -> Self {
         PrimaryFlightDisplayData::default()
+    }
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl HSIMode {
+    pub fn __str__(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("HSIMode::{}", self)
+    }
+
+    #[pyo3(name = "to_int")]
+    fn py_to_int(&self) -> i32 {
+        self.to_int()
+    }
+
+    #[staticmethod]
+    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+        let dict = pyo3::types::PyDict::new(py);
+        for variant in [HSIMode::GPS, HSIMode::VOR1, HSIMode::VOR2] {
+            dict.set_item(variant.to_string(), variant.to_int())?;
+        }
+        Ok(dict.into())
+    }
+
+    #[classattr]
+    fn __type_support__() -> Py<PyCapsule> {
+        PyTypeSupport::create::<Self>()
     }
 }
 

--- a/aerosim-data/src/types/flight_deck.rs
+++ b/aerosim-data/src/types/flight_deck.rs
@@ -103,7 +103,8 @@ impl HSIMode {
     }
 
     #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(py: Python) -> PyResult<PyObject> {
         let dict = pyo3::types::PyDict::new(py);
         for variant in [HSIMode::GPS, HSIMode::VOR1, HSIMode::VOR2] {
             dict.set_item(variant.to_string(), variant.to_int())?;
@@ -125,7 +126,8 @@ impl PrimaryFlightDisplayData {
         Self::new()
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("airspeed_kts", self.airspeed_kts)?;
         dict.set_item("true_airspeed_kts", self.true_airspeed_kts)?;

--- a/aerosim-data/src/types/geometry.rs
+++ b/aerosim-data/src/types/geometry.rs
@@ -1,11 +1,18 @@
-use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{types::PyTypeSupport, AerosimMessage};
+use crate::AerosimMessage;
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(
     Clone,
     Copy,
@@ -32,12 +39,19 @@ impl Default for Vector3 {
     }
 }
 
+impl Vector3 {
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        Vector3 { x, y, z }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl Vector3 {
     #[new]
     #[pyo3(signature = (x=Vector3::default().x, y=Vector3::default().y, z=Vector3::default().z))]
-    pub fn new(x: f64, y: f64, z: f64) -> Self {
-        Vector3 { x, y, z }
+    fn py_new(x: f64, y: f64, z: f64) -> Self {
+        Self::new(x, y, z)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -54,7 +68,7 @@ impl Vector3 {
     }
 }
 
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, AerosimMessage, JsonSchema)]
 pub struct Quaternion {
     pub w: f64,
@@ -74,12 +88,19 @@ impl Default for Quaternion {
     }
 }
 
+impl Quaternion {
+    pub fn new(w: f64, x: f64, y: f64, z: f64) -> Self {
+        Quaternion { w, x, y, z }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl Quaternion {
     #[new]
     #[pyo3(signature = (w=Quaternion::default().w, x=Quaternion::default().x, y=Quaternion::default().y, z=Quaternion::default().z))]
-    pub fn new(w: f64, x: f64, y: f64, z: f64) -> Self {
-        Quaternion { w, x, y, z }
+    fn py_new(w: f64, x: f64, y: f64, z: f64) -> Self {
+        Self::new(w, x, y, z)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -97,22 +118,28 @@ impl Quaternion {
     }
 }
 
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, AerosimMessage, JsonSchema)]
-
 pub struct Pose {
     pub position: Vector3,
     pub orientation: Quaternion,
 }
 
-#[pymethods]
 impl Pose {
-    #[new]
     pub fn new(position: Vector3, orientation: Quaternion) -> Self {
         Pose {
             position,
             orientation,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Pose {
+    #[new]
+    fn py_new(position: Vector3, orientation: Quaternion) -> Self {
+        Self::new(position, orientation)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -128,9 +155,7 @@ impl Pose {
     }
 }
 
-// Add tests for the geometry module
 #[cfg(test)]
-
 mod tests {
 
     #[test]

--- a/aerosim-data/src/types/geometry.rs
+++ b/aerosim-data/src/types/geometry.rs
@@ -45,29 +45,6 @@ impl Vector3 {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl Vector3 {
-    #[new]
-    #[pyo3(signature = (x=Vector3::default().x, y=Vector3::default().y, z=Vector3::default().z))]
-    fn py_new(x: f64, y: f64, z: f64) -> Self {
-        Self::new(x, y, z)
-    }
-
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        dict.set_item("x", self.x)?;
-        dict.set_item("y", self.y)?;
-        dict.set_item("z", self.z)?;
-        Ok(dict.into())
-    }
-
-    #[classattr]
-    fn __type_support__() -> Py<PyCapsule> {
-        PyTypeSupport::create::<Self>()
-    }
-}
-
 #[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, AerosimMessage, JsonSchema)]
 pub struct Quaternion {
@@ -94,6 +71,47 @@ impl Quaternion {
     }
 }
 
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, AerosimMessage, JsonSchema)]
+pub struct Pose {
+    pub position: Vector3,
+    pub orientation: Quaternion,
+}
+
+impl Pose {
+    pub fn new(position: Vector3, orientation: Quaternion) -> Self {
+        Pose {
+            position,
+            orientation,
+        }
+    }
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Vector3 {
+    #[new]
+    #[pyo3(signature = (x=Vector3::default().x, y=Vector3::default().y, z=Vector3::default().z))]
+    fn py_new(x: f64, y: f64, z: f64) -> Self {
+        Self::new(x, y, z)
+    }
+
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("x", self.x)?;
+        dict.set_item("y", self.y)?;
+        dict.set_item("z", self.z)?;
+        Ok(dict.into())
+    }
+
+    #[classattr]
+    fn __type_support__() -> Py<PyCapsule> {
+        PyTypeSupport::create::<Self>()
+    }
+}
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl Quaternion {
@@ -115,22 +133,6 @@ impl Quaternion {
     #[classattr]
     fn __type_support__() -> Py<PyCapsule> {
         PyTypeSupport::create::<Self>()
-    }
-}
-
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, AerosimMessage, JsonSchema)]
-pub struct Pose {
-    pub position: Vector3,
-    pub orientation: Quaternion,
-}
-
-impl Pose {
-    pub fn new(position: Vector3, orientation: Quaternion) -> Self {
-        Pose {
-            position,
-            orientation,
-        }
     }
 }
 

--- a/aerosim-data/src/types/geometry.rs
+++ b/aerosim-data/src/types/geometry.rs
@@ -98,7 +98,8 @@ impl Vector3 {
         Self::new(x, y, z)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("x", self.x)?;
         dict.set_item("y", self.y)?;
@@ -121,7 +122,8 @@ impl Quaternion {
         Self::new(w, x, y, z)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("w", self.w)?;
         dict.set_item("x", self.x)?;
@@ -144,10 +146,11 @@ impl Pose {
         Self::new(position, orientation)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("position", self.position.to_dict(py)?)?;
-        dict.set_item("orientation", self.orientation.to_dict(py)?)?;
+        dict.set_item("position", self.position.py_to_dict(py)?)?;
+        dict.set_item("orientation", self.orientation.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 

--- a/aerosim-data/src/types/header.rs
+++ b/aerosim-data/src/types/header.rs
@@ -80,10 +80,11 @@ impl Header {
         self.is_sim_time_valid()
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("timestamp_sim", self.timestamp_sim.to_dict(py)?)?;
-        dict.set_item("timestamp_platform", self.timestamp_platform.to_dict(py)?)?;
+        dict.set_item("timestamp_sim", self.timestamp_sim.py_to_dict(py)?)?;
+        dict.set_item("timestamp_platform", self.timestamp_platform.py_to_dict(py)?)?;
         dict.set_item("frame_id", self.frame_id.clone())?;
         Ok(dict.into())
     }

--- a/aerosim-data/src/types/header.rs
+++ b/aerosim-data/src/types/header.rs
@@ -1,11 +1,12 @@
 use super::timestamp::TimeStamp;
-use pyo3::prelude::*;
-use pyo3::types::PyDict;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "python")]
+use pyo3::{prelude::*, types::PyDict};
 
 const SENTINEL_SECONDS: i32 = i32::MIN;
 
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Header {
     /// Discrete simulation time.
@@ -19,9 +20,7 @@ pub struct Header {
     pub frame_id: String,
 }
 
-#[pymethods]
 impl Header {
-    #[new]
     pub fn new(timestamp_sim: TimeStamp, timestamp_platform: TimeStamp, frame_id: &str) -> Self {
         Header {
             timestamp_sim,
@@ -30,13 +29,6 @@ impl Header {
         }
     }
 
-    #[staticmethod]
-    #[pyo3(name = "default")]
-    pub fn _default() -> Self {
-        Self::default()
-    }
-
-    #[staticmethod]
     pub fn with_timestamp(timestamp: TimeStamp) -> Self {
         Header {
             timestamp_sim: timestamp,
@@ -48,6 +40,33 @@ impl Header {
     pub fn is_sim_time_valid(&self) -> bool {
         self.timestamp_sim.sec >= 0
     }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Header {
+    #[new]
+    #[pyo3(signature = (timestamp_sim, timestamp_platform, frame_id))]
+    fn py_new(timestamp_sim: TimeStamp, timestamp_platform: TimeStamp, frame_id: &str) -> Self {
+        Self::new(timestamp_sim, timestamp_platform, frame_id)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "default")]
+    pub fn py_default() -> Self {
+        Self::default()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "with_timestamp")]
+    fn py_with_timestamp(timestamp: TimeStamp) -> Self {
+        Self::with_timestamp(timestamp)
+    }
+
+    #[pyo3(name = "is_sim_time_valid")]
+    fn py_is_sim_time_valid(&self) -> bool {
+        self.is_sim_time_valid()
+    }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -58,17 +77,15 @@ impl Header {
     }
 }
 
-
 impl Default for Header {
     fn default() -> Self {
         Header {
             timestamp_sim: TimeStamp::new(SENTINEL_SECONDS, 0),
             timestamp_platform: TimeStamp::now(),
-            frame_id: "".to_string()
+            frame_id: "".to_string(),
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/aerosim-data/src/types/header.rs
+++ b/aerosim-data/src/types/header.rs
@@ -42,6 +42,18 @@ impl Header {
     }
 }
 
+impl Default for Header {
+    fn default() -> Self {
+        Header {
+            timestamp_sim: TimeStamp::new(SENTINEL_SECONDS, 0),
+            timestamp_platform: TimeStamp::now(),
+            frame_id: "".to_string(),
+        }
+    }
+}
+
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl Header {
@@ -74,16 +86,6 @@ impl Header {
         dict.set_item("timestamp_platform", self.timestamp_platform.to_dict(py)?)?;
         dict.set_item("frame_id", self.frame_id.clone())?;
         Ok(dict.into())
-    }
-}
-
-impl Default for Header {
-    fn default() -> Self {
-        Header {
-            timestamp_sim: TimeStamp::new(SENTINEL_SECONDS, 0),
-            timestamp_platform: TimeStamp::now(),
-            frame_id: "".to_string(),
-        }
     }
 }
 

--- a/aerosim-data/src/types/json.rs
+++ b/aerosim-data/src/types/json.rs
@@ -36,7 +36,7 @@ impl JsonData {
 #[pymethods]
 impl JsonData {
     #[new]
-    pub fn pynew(py: Python, data: PyObject) -> PyResult<Self> {
+    pub fn py_new(py: Python, data: PyObject) -> PyResult<Self> {
         let json: serde_json::Value = depythonize(&data.into_bound(py)).map_err(|e| {
             PyValueError::new_err(format!("Failed to deserialize from Python object: {}", e))
         })?;
@@ -46,7 +46,7 @@ impl JsonData {
     }
 
     #[pyo3(name = "get_data")]
-    pub fn pyget_data(&self, py: Python) -> PyResult<PyObject> {
+    pub fn py_get_data(&self, py: Python) -> PyResult<PyObject> {
         let json = self
             .get_data()
             .ok_or_else(|| PyValueError::new_err(format!("Failed to deserialize JSON data")))?;
@@ -56,8 +56,9 @@ impl JsonData {
         Ok(obj.into())
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        self.pyget_data(py)
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
+        self.py_get_data(py)
     }
 
     #[classattr]

--- a/aerosim-data/src/types/json.rs
+++ b/aerosim-data/src/types/json.rs
@@ -1,14 +1,16 @@
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::types::PyTypeSupport;
 use crate::AerosimMessage;
 
-use pyo3::{exceptions::PyValueError, prelude::*, types::PyCapsule};
-use pythonize::{depythonize, pythonize};
-use serde::{Deserialize, Serialize};
-use serde_json;
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{exceptions::PyValueError, prelude::*, types::PyCapsule},
+    pythonize::{depythonize, pythonize},
+};
 
-#[pyclass]
+#[cfg_attr(feature = "python", pyclass)]
 #[derive(
     Clone, Debug, Serialize, Deserialize, PartialEq, aerosim_macros::AerosimMessage, JsonSchema,
 )]
@@ -28,6 +30,7 @@ impl JsonData {
     }
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl JsonData {
     #[new]

--- a/aerosim-data/src/types/json.rs
+++ b/aerosim-data/src/types/json.rs
@@ -30,6 +30,8 @@ impl JsonData {
     }
 }
 
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl JsonData {

--- a/aerosim-data/src/types/mod.rs
+++ b/aerosim-data/src/types/mod.rs
@@ -43,9 +43,10 @@ mod registry;
 pub use registry::TypeRegistry;
 
 mod typesupport;
+pub use typesupport::TypeSupport;
+
 #[cfg(feature = "python")]
 pub use typesupport::PyTypeSupport;
-pub use typesupport::TypeSupport;
 
 use serde::{Deserialize, Serialize};
 

--- a/aerosim-data/src/types/mod.rs
+++ b/aerosim-data/src/types/mod.rs
@@ -43,7 +43,9 @@ mod registry;
 pub use registry::TypeRegistry;
 
 mod typesupport;
-pub use typesupport::{PyTypeSupport, TypeSupport};
+#[cfg(feature = "python")]
+pub use typesupport::PyTypeSupport;
+pub use typesupport::TypeSupport;
 
 use serde::{Deserialize, Serialize};
 

--- a/aerosim-data/src/types/sensor.rs
+++ b/aerosim-data/src/types/sensor.rs
@@ -1,24 +1,26 @@
 use std::borrow::Cow;
 
-use pyo3::{
-    exceptions::PyRuntimeError,
-    prelude::*,
-    types::{PyCapsule, PyDict},
-};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use turbojpeg;
 
-use crate::{
-    types::{downlink_format::DownlinkFormat, PyTypeSupport},
-    AerosimMessage,
-};
+use crate::{types::downlink_format::DownlinkFormat, AerosimMessage};
 
 use super::Vector3;
 
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        exceptions::PyRuntimeError,
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, EnumString, Display)]
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 pub enum SensorType {
     Camera,
     GNSS,
@@ -28,6 +30,7 @@ pub enum SensorType {
     RADAR,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl SensorType {
     #[staticmethod]
@@ -64,7 +67,7 @@ impl SensorType {
 // Image types
 
 #[derive(Clone, Debug, Serialize, Deserialize, EnumString, Display, PartialEq)]
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 pub enum ImageEncoding {
     RGB8,
     RGBA8,
@@ -77,12 +80,13 @@ pub enum ImageEncoding {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, EnumString, Display, PartialEq)]
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 pub enum ImageFormat {
     JPEG,
     PNG,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl ImageEncoding {
     #[staticmethod]
@@ -117,25 +121,14 @@ impl ImageEncoding {
     }
 }
 
-#[pyclass]
 #[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage)]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct Image {
-    #[pyo3(get, set)]
     pub camera_info: CameraInfo,
-
-    #[pyo3(get, set)]
     pub height: u32,
-
-    #[pyo3(get, set)]
     pub width: u32,
-
-    #[pyo3(get, set)]
     pub encoding: ImageEncoding,
-
-    #[pyo3(get, set)]
     pub is_bigendian: u8,
-
-    #[pyo3(get, set)]
     pub step: u32,
 
     #[serde(
@@ -145,9 +138,7 @@ pub struct Image {
     pub data: Cow<'static, [u8]>,
 }
 
-#[pymethods]
 impl Image {
-    #[new]
     pub fn new(
         camera_info: CameraInfo,
         height: u32,
@@ -168,12 +159,7 @@ impl Image {
         }
     }
 
-    #[getter]
-    fn data(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-
-    pub fn compress(&self) -> PyResult<CompressedImage> {
+    pub fn compress(&self) -> Result<CompressedImage, String> {
         let pixel_format = match self.encoding {
             ImageEncoding::RGB8 => turbojpeg::PixelFormat::RGB,
             ImageEncoding::RGBA8 => turbojpeg::PixelFormat::RGBA,
@@ -189,19 +175,105 @@ impl Image {
             format: pixel_format,
         };
 
-        let mut compressor = turbojpeg::Compressor::new().map_err(|e| {
-            PyRuntimeError::new_err(format!("Could not create turbojpeg compressor: {}", e))
-        })?;
+        let mut compressor = turbojpeg::Compressor::new()
+            .map_err(|e| format!("Could not create turbojpeg compressor: {}", e))?;
         let _ = compressor.set_quality(80);
         let _ = compressor.set_subsamp(turbojpeg::Subsamp::Sub2x2);
-        let data = compressor.compress_to_vec(raw_img).map_err(|e| {
-            PyRuntimeError::new_err(format!("Could not compress raw image to jpeg: {}", e))
-        })?;
+        let data = compressor
+            .compress_to_vec(raw_img)
+            .map_err(|e| format!("Could not compress raw image to jpeg: {}", e))?;
 
         Ok(CompressedImage {
             format: ImageFormat::JPEG,
             data: Cow::Owned(data),
         })
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl Image {
+    #[new]
+    fn py_new(
+        camera_info: CameraInfo,
+        height: u32,
+        width: u32,
+        encoding: ImageEncoding,
+        is_bigendian: u8,
+        step: u32,
+        data: Vec<u8>,
+    ) -> Self {
+        Self::new(camera_info, height, width, encoding, is_bigendian, step, data)
+    }
+
+    #[getter]
+    fn camera_info(&self) -> CameraInfo {
+        self.camera_info.clone()
+    }
+
+    #[setter]
+    fn set_camera_info(&mut self, camera_info: CameraInfo) {
+        self.camera_info = camera_info;
+    }
+
+    #[getter]
+    fn height(&self) -> u32 {
+        self.height
+    }
+
+    #[setter]
+    fn set_height(&mut self, height: u32) {
+        self.height = height;
+    }
+
+    #[getter]
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    #[setter]
+    fn set_width(&mut self, width: u32) {
+        self.width = width;
+    }
+
+    #[getter]
+    fn encoding(&self) -> ImageEncoding {
+        self.encoding.clone()
+    }
+
+    #[setter]
+    fn set_encoding(&mut self, encoding: ImageEncoding) {
+        self.encoding = encoding;
+    }
+
+    #[getter]
+    fn is_bigendian(&self) -> u8 {
+        self.is_bigendian
+    }
+
+    #[setter]
+    fn set_is_bigendian(&mut self, is_bigendian: u8) {
+        self.is_bigendian = is_bigendian;
+    }
+
+    #[getter]
+    fn step(&self) -> u32 {
+        self.step
+    }
+
+    #[setter]
+    fn set_step(&mut self, step: u32) {
+        self.step = step;
+    }
+
+    #[getter]
+    fn data(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+
+    #[pyo3(name = "compress")]
+    pub fn py_compress(&self) -> PyResult<CompressedImage> {
+        self.compress().map_err(PyRuntimeError::new_err)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -234,10 +306,9 @@ impl Image {
     }
 }
 
-#[pyclass]
 #[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage)]
+#[cfg_attr(feature = "python", pyclass)]
 pub struct CompressedImage {
-    #[pyo3(get, set)]
     pub format: ImageFormat,
 
     #[serde(
@@ -247,9 +318,7 @@ pub struct CompressedImage {
     pub data: Cow<'static, [u8]>,
 }
 
-#[pymethods]
 impl CompressedImage {
-    #[new]
     pub fn new(format: ImageFormat, data: Vec<u8>) -> Self {
         CompressedImage {
             format,
@@ -257,18 +326,12 @@ impl CompressedImage {
         }
     }
 
-    #[getter]
-    fn data(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-
-    fn decompress(&self) -> PyResult<Image> {
-        let mut decompressor = turbojpeg::Decompressor::new().map_err(|e| {
-            PyRuntimeError::new_err(format!("Could not create turbojpeg decompresor: {}", e))
-        })?;
-        let header = decompressor.read_header(self.data.as_ref()).map_err(|e| {
-            PyRuntimeError::new_err(format!("Could not read header from jpeg image: {}", e))
-        })?;
+    pub fn decompress(&self) -> Result<Image, String> {
+        let mut decompressor = turbojpeg::Decompressor::new()
+            .map_err(|e| format!("Could not create turbojpeg decompresor: {}", e))?;
+        let header = decompressor
+            .read_header(self.data.as_ref())
+            .map_err(|e| format!("Could not read header from jpeg image: {}", e))?;
 
         // FIXME: Currently hardcoded to BGRA as used in the renderer
         let pitch = header.width * 4;
@@ -281,9 +344,7 @@ impl CompressedImage {
         };
         decompressor
             .decompress(self.data.as_ref(), image.as_deref_mut())
-            .map_err(|e| {
-                PyRuntimeError::new_err(format!("Could not decompress jpeg image: {}", e))
-            })?;
+            .map_err(|e| format!("Could not decompress jpeg image: {}", e))?;
 
         // FIXME: Currently hardcoding some values as in the renderer.
         // TODO: Some parameters (e.g., CameraInfo) cannot be derived from the compressed image.
@@ -309,6 +370,35 @@ impl CompressedImage {
             step: pitch as u32,
             data: Cow::Owned(image.pixels),
         })
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl CompressedImage {
+    #[new]
+    fn py_new(format: ImageFormat, data: Vec<u8>) -> Self {
+        Self::new(format, data)
+    }
+
+    #[getter]
+    fn format(&self) -> ImageFormat {
+        self.format.clone()
+    }
+
+    #[setter]
+    fn set_format(&mut self, format: ImageFormat) {
+        self.format = format;
+    }
+
+    #[getter]
+    fn data(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+
+    #[pyo3(name = "decompress")]
+    fn py_decompress(&self) -> PyResult<Image> {
+        self.decompress().map_err(PyRuntimeError::new_err)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -346,8 +436,8 @@ where
     Ok(Cow::Owned(bytes))
 }
 
-#[pyclass(get_all, set_all)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct CameraInfo {
     pub width: u32,
     pub height: u32,
@@ -358,9 +448,7 @@ pub struct CameraInfo {
     pub p: [f64; 12],
 }
 
-#[pymethods]
 impl CameraInfo {
-    #[new]
     pub fn new(
         width: u32,
         height: u32,
@@ -380,6 +468,23 @@ impl CameraInfo {
             p,
         }
     }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl CameraInfo {
+    #[new]
+    fn py_new(
+        width: u32,
+        height: u32,
+        distortion_model: String,
+        d: Vec<f64>,
+        k: [f64; 9],
+        r: [f64; 9],
+        p: [f64; 12],
+    ) -> Self {
+        Self::new(width, height, distortion_model, d, k, r, p)
+    }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -394,8 +499,8 @@ impl CameraInfo {
     }
 }
 
-#[pyclass(get_all, set_all)]
 #[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct ADSB {
     pub message: DownlinkFormat,
 }
@@ -410,12 +515,19 @@ impl Default for ADSB {
     }
 }
 
+impl ADSB {
+    pub fn new(message: DownlinkFormat) -> Self {
+        ADSB { message }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl ADSB {
     #[new]
     #[pyo3(signature = (message=DownlinkFormat::GNSSPositionData(crate::types::adsb::gnss_position_data::GNSSPositionData::default())))]
-    pub fn new(message: DownlinkFormat) -> Self {
-        ADSB { message }
+    fn py_new(message: DownlinkFormat) -> Self {
+        Self::new(message)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -425,8 +537,8 @@ impl ADSB {
     }
 }
 
-#[pyclass(get_all, set_all)]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct GNSS {
     pub latitude: f64,
     pub longitude: f64,
@@ -435,10 +547,7 @@ pub struct GNSS {
     pub heading: f64,
 }
 
-#[pymethods]
 impl GNSS {
-    #[new]
-    #[pyo3(signature = (latitude=0.0, longitude=0.0, altitude=0.0, velocity=Vector3::default(), heading=0.0))]
     pub fn new(
         latitude: f64,
         longitude: f64,
@@ -454,6 +563,22 @@ impl GNSS {
             heading,
         }
     }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl GNSS {
+    #[new]
+    #[pyo3(signature = (latitude=0.0, longitude=0.0, altitude=0.0, velocity=Vector3::default(), heading=0.0))]
+    fn py_new(
+        latitude: f64,
+        longitude: f64,
+        altitude: f64,
+        velocity: Vector3,
+        heading: f64,
+    ) -> Self {
+        Self::new(latitude, longitude, altitude, velocity, heading)
+    }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
@@ -466,24 +591,31 @@ impl GNSS {
     }
 }
 
-#[pyclass(get_all, set_all)]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct IMU {
-    acceleration: Vector3,
-    gyroscope: Vector3,
-    magnetic_field: Vector3,
+    pub acceleration: Vector3,
+    pub gyroscope: Vector3,
+    pub magnetic_field: Vector3,
 }
 
-#[pymethods]
 impl IMU {
-    #[new]
-    #[pyo3(signature = (acceleration=Vector3::default(), gyroscope=Vector3::default(), magnetic_field=Vector3::default()))]
     pub fn new(acceleration: Vector3, gyroscope: Vector3, magnetic_field: Vector3) -> Self {
         IMU {
             acceleration,
             gyroscope,
             magnetic_field,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl IMU {
+    #[new]
+    #[pyo3(signature = (acceleration=Vector3::default(), gyroscope=Vector3::default(), magnetic_field=Vector3::default()))]
+    fn py_new(acceleration: Vector3, gyroscope: Vector3, magnetic_field: Vector3) -> Self {
+        Self::new(acceleration, gyroscope, magnetic_field)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/sensor.rs
+++ b/aerosim-data/src/types/sensor.rs
@@ -30,40 +30,6 @@ pub enum SensorType {
     RADAR,
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl SensorType {
-    #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
-        s.parse()
-            .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid SensorType"))
-    }
-
-    pub fn __str__(&self) -> String {
-        self.to_string()
-    }
-
-    pub fn __repr__(&self) -> String {
-        format!("SensorType::{}", self)
-    }
-
-    #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        for variant in [
-            SensorType::Camera,
-            SensorType::GNSS,
-            SensorType::ADSB,
-            SensorType::IMU,
-            SensorType::LIDAR,
-            SensorType::RADAR,
-        ] {
-            dict.set_item(variant.to_string(), variant.__repr__())?;
-        }
-        Ok(dict.into())
-    }
-}
-
 // Image types
 
 #[derive(Clone, Debug, Serialize, Deserialize, EnumString, Display, PartialEq)]
@@ -84,41 +50,6 @@ pub enum ImageEncoding {
 pub enum ImageFormat {
     JPEG,
     PNG,
-}
-
-#[cfg(feature = "python")]
-#[pymethods]
-impl ImageEncoding {
-    #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
-        s.parse()
-            .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid ImageEncoding"))
-    }
-
-    pub fn __str__(&self) -> String {
-        self.to_string()
-    }
-
-    pub fn __repr__(&self) -> String {
-        format!("ImageEncoding::{}", self)
-    }
-
-    #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
-        let dict = pyo3::types::PyDict::new(py);
-        for variant in [
-            ImageEncoding::RGB8,
-            ImageEncoding::RGBA8,
-            ImageEncoding::BGR8,
-            ImageEncoding::BGRA8,
-            ImageEncoding::MONO8,
-            ImageEncoding::MONO16,
-            ImageEncoding::YUV422,
-        ] {
-            dict.set_item(variant.to_string(), variant.__repr__())?;
-        }
-        Ok(dict.into())
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage)]
@@ -187,6 +118,262 @@ impl Image {
             format: ImageFormat::JPEG,
             data: Cow::Owned(data),
         })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage)]
+#[cfg_attr(feature = "python", pyclass)]
+pub struct CompressedImage {
+    pub format: ImageFormat,
+
+    #[serde(
+        serialize_with = "serialize_pixels",
+        deserialize_with = "deserialize_pixels"
+    )]
+    pub data: Cow<'static, [u8]>,
+}
+
+impl CompressedImage {
+    pub fn new(format: ImageFormat, data: Vec<u8>) -> Self {
+        CompressedImage {
+            format,
+            data: Cow::Owned(data),
+        }
+    }
+
+    pub fn decompress(&self) -> Result<Image, String> {
+        let mut decompressor = turbojpeg::Decompressor::new()
+            .map_err(|e| format!("Could not create turbojpeg decompresor: {}", e))?;
+        let header = decompressor
+            .read_header(self.data.as_ref())
+            .map_err(|e| format!("Could not read header from jpeg image: {}", e))?;
+
+        // FIXME: Currently hardcoded to BGRA as used in the renderer
+        let pitch = header.width * 4;
+        let mut image = turbojpeg::Image {
+            pixels: vec![0; header.height * pitch],
+            width: header.width,
+            pitch,
+            height: header.height,
+            format: turbojpeg::PixelFormat::BGRA,
+        };
+        decompressor
+            .decompress(self.data.as_ref(), image.as_deref_mut())
+            .map_err(|e| format!("Could not decompress jpeg image: {}", e))?;
+
+        // FIXME: Currently hardcoding some values as in the renderer.
+        // TODO: Some parameters (e.g., CameraInfo) cannot be derived from the compressed image.
+        // Consider using a single data type for consistency?
+        let d: Vec<f64> = vec![0.0];
+        let k: [f64; 9] = [0.0; 9];
+        let r: [f64; 9] = [0.0; 9];
+        let p: [f64; 12] = [0.0; 12];
+        Ok(Image {
+            camera_info: CameraInfo::new(
+                header.width as u32,
+                header.height as u32,
+                "none".to_string(),
+                d,
+                k,
+                r,
+                p,
+            ),
+            height: header.height as u32,
+            width: header.width as u32,
+            encoding: ImageEncoding::BGRA8,
+            is_bigendian: 0,
+            step: pitch as u32,
+            data: Cow::Owned(image.pixels),
+        })
+    }
+}
+
+fn serialize_pixels<S>(data: &Cow<'_, [u8]>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serde_bytes::serialize(data.as_ref(), serializer)
+}
+
+fn deserialize_pixels<'de, D>(deserializer: D) -> Result<Cow<'static, [u8]>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
+    let bytes = bytes.into_vec();
+    Ok(Cow::Owned(bytes))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct CameraInfo {
+    pub width: u32,
+    pub height: u32,
+    pub distortion_model: String,
+    pub d: Vec<f64>,
+    pub k: [f64; 9],
+    pub r: [f64; 9],
+    pub p: [f64; 12],
+}
+
+impl CameraInfo {
+    pub fn new(
+        width: u32,
+        height: u32,
+        distortion_model: String,
+        d: Vec<f64>,
+        k: [f64; 9],
+        r: [f64; 9],
+        p: [f64; 12],
+    ) -> Self {
+        CameraInfo {
+            width,
+            height,
+            distortion_model,
+            d,
+            k,
+            r,
+            p,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct ADSB {
+    pub message: DownlinkFormat,
+}
+
+impl Default for ADSB {
+    fn default() -> Self {
+        ADSB {
+            message: DownlinkFormat::GNSSPositionData(
+                crate::types::adsb::gnss_position_data::GNSSPositionData::default(),
+            ),
+        }
+    }
+}
+
+impl ADSB {
+    pub fn new(message: DownlinkFormat) -> Self {
+        ADSB { message }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct GNSS {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub altitude: f64,
+    pub velocity: Vector3,
+    pub heading: f64,
+}
+
+impl GNSS {
+    pub fn new(
+        latitude: f64,
+        longitude: f64,
+        altitude: f64,
+        velocity: Vector3,
+        heading: f64,
+    ) -> Self {
+        GNSS {
+            latitude,
+            longitude,
+            altitude,
+            velocity,
+            heading,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct IMU {
+    pub acceleration: Vector3,
+    pub gyroscope: Vector3,
+    pub magnetic_field: Vector3,
+}
+
+impl IMU {
+    pub fn new(acceleration: Vector3, gyroscope: Vector3, magnetic_field: Vector3) -> Self {
+        IMU {
+            acceleration,
+            gyroscope,
+            magnetic_field,
+        }
+    }
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl SensorType {
+    #[staticmethod]
+    pub fn from_str(s: &str) -> PyResult<Self> {
+        s.parse()
+            .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid SensorType"))
+    }
+
+    pub fn __str__(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("SensorType::{}", self)
+    }
+
+    #[staticmethod]
+    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+        let dict = pyo3::types::PyDict::new(py);
+        for variant in [
+            SensorType::Camera,
+            SensorType::GNSS,
+            SensorType::ADSB,
+            SensorType::IMU,
+            SensorType::LIDAR,
+            SensorType::RADAR,
+        ] {
+            dict.set_item(variant.to_string(), variant.__repr__())?;
+        }
+        Ok(dict.into())
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ImageEncoding {
+    #[staticmethod]
+    pub fn from_str(s: &str) -> PyResult<Self> {
+        s.parse()
+            .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid ImageEncoding"))
+    }
+
+    pub fn __str__(&self) -> String {
+        self.to_string()
+    }
+
+    pub fn __repr__(&self) -> String {
+        format!("ImageEncoding::{}", self)
+    }
+
+    #[staticmethod]
+    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+        let dict = pyo3::types::PyDict::new(py);
+        for variant in [
+            ImageEncoding::RGB8,
+            ImageEncoding::RGBA8,
+            ImageEncoding::BGR8,
+            ImageEncoding::BGRA8,
+            ImageEncoding::MONO8,
+            ImageEncoding::MONO16,
+            ImageEncoding::YUV422,
+        ] {
+            dict.set_item(variant.to_string(), variant.__repr__())?;
+        }
+        Ok(dict.into())
     }
 }
 
@@ -306,73 +493,6 @@ impl Image {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage)]
-#[cfg_attr(feature = "python", pyclass)]
-pub struct CompressedImage {
-    pub format: ImageFormat,
-
-    #[serde(
-        serialize_with = "serialize_pixels",
-        deserialize_with = "deserialize_pixels"
-    )]
-    pub data: Cow<'static, [u8]>,
-}
-
-impl CompressedImage {
-    pub fn new(format: ImageFormat, data: Vec<u8>) -> Self {
-        CompressedImage {
-            format,
-            data: Cow::Owned(data),
-        }
-    }
-
-    pub fn decompress(&self) -> Result<Image, String> {
-        let mut decompressor = turbojpeg::Decompressor::new()
-            .map_err(|e| format!("Could not create turbojpeg decompresor: {}", e))?;
-        let header = decompressor
-            .read_header(self.data.as_ref())
-            .map_err(|e| format!("Could not read header from jpeg image: {}", e))?;
-
-        // FIXME: Currently hardcoded to BGRA as used in the renderer
-        let pitch = header.width * 4;
-        let mut image = turbojpeg::Image {
-            pixels: vec![0; header.height * pitch],
-            width: header.width,
-            pitch,
-            height: header.height,
-            format: turbojpeg::PixelFormat::BGRA,
-        };
-        decompressor
-            .decompress(self.data.as_ref(), image.as_deref_mut())
-            .map_err(|e| format!("Could not decompress jpeg image: {}", e))?;
-
-        // FIXME: Currently hardcoding some values as in the renderer.
-        // TODO: Some parameters (e.g., CameraInfo) cannot be derived from the compressed image.
-        // Consider using a single data type for consistency?
-        let d: Vec<f64> = vec![0.0];
-        let k: [f64; 9] = [0.0; 9];
-        let r: [f64; 9] = [0.0; 9];
-        let p: [f64; 12] = [0.0; 12];
-        Ok(Image {
-            camera_info: CameraInfo::new(
-                header.width as u32,
-                header.height as u32,
-                "none".to_string(),
-                d,
-                k,
-                r,
-                p,
-            ),
-            height: header.height as u32,
-            width: header.width as u32,
-            encoding: ImageEncoding::BGRA8,
-            is_bigendian: 0,
-            step: pitch as u32,
-            data: Cow::Owned(image.pixels),
-        })
-    }
-}
-
 #[cfg(feature = "python")]
 #[pymethods]
 impl CompressedImage {
@@ -420,56 +540,6 @@ impl CompressedImage {
     }
 }
 
-fn serialize_pixels<S>(data: &Cow<'_, [u8]>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serde_bytes::serialize(data.as_ref(), serializer)
-}
-
-fn deserialize_pixels<'de, D>(deserializer: D) -> Result<Cow<'static, [u8]>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
-    let bytes = bytes.into_vec();
-    Ok(Cow::Owned(bytes))
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct CameraInfo {
-    pub width: u32,
-    pub height: u32,
-    pub distortion_model: String,
-    pub d: Vec<f64>,
-    pub k: [f64; 9],
-    pub r: [f64; 9],
-    pub p: [f64; 12],
-}
-
-impl CameraInfo {
-    pub fn new(
-        width: u32,
-        height: u32,
-        distortion_model: String,
-        d: Vec<f64>,
-        k: [f64; 9],
-        r: [f64; 9],
-        p: [f64; 12],
-    ) -> Self {
-        CameraInfo {
-            width,
-            height,
-            distortion_model,
-            d,
-            k,
-            r,
-            p,
-        }
-    }
-}
-
 #[cfg(feature = "python")]
 #[pymethods]
 impl CameraInfo {
@@ -499,28 +569,6 @@ impl CameraInfo {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct ADSB {
-    pub message: DownlinkFormat,
-}
-
-impl Default for ADSB {
-    fn default() -> Self {
-        ADSB {
-            message: DownlinkFormat::GNSSPositionData(
-                crate::types::adsb::gnss_position_data::GNSSPositionData::default(),
-            ),
-        }
-    }
-}
-
-impl ADSB {
-    pub fn new(message: DownlinkFormat) -> Self {
-        ADSB { message }
-    }
-}
-
 #[cfg(feature = "python")]
 #[pymethods]
 impl ADSB {
@@ -534,34 +582,6 @@ impl ADSB {
         let dict = PyDict::new(py);
         let _ = dict.set_item("message", self.message.to_dict(py)?);
         Ok(dict.into())
-    }
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct GNSS {
-    pub latitude: f64,
-    pub longitude: f64,
-    pub altitude: f64,
-    pub velocity: Vector3,
-    pub heading: f64,
-}
-
-impl GNSS {
-    pub fn new(
-        latitude: f64,
-        longitude: f64,
-        altitude: f64,
-        velocity: Vector3,
-        heading: f64,
-    ) -> Self {
-        GNSS {
-            latitude,
-            longitude,
-            altitude,
-            velocity,
-            heading,
-        }
     }
 }
 
@@ -588,24 +608,6 @@ impl GNSS {
         dict.set_item("velocity", self.velocity.to_dict(py)?)?;
         dict.set_item("heading", self.heading)?;
         Ok(dict.into())
-    }
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct IMU {
-    pub acceleration: Vector3,
-    pub gyroscope: Vector3,
-    pub magnetic_field: Vector3,
-}
-
-impl IMU {
-    pub fn new(acceleration: Vector3, gyroscope: Vector3, magnetic_field: Vector3) -> Self {
-        IMU {
-            acceleration,
-            gyroscope,
-            magnetic_field,
-        }
     }
 }
 

--- a/aerosim-data/src/types/sensor.rs
+++ b/aerosim-data/src/types/sensor.rs
@@ -312,7 +312,8 @@ impl IMU {
 #[pymethods]
 impl SensorType {
     #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
+    #[pyo3(name = "from_str")]
+    pub fn py_from_str(s: &str) -> PyResult<Self> {
         s.parse()
             .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid SensorType"))
     }
@@ -326,7 +327,8 @@ impl SensorType {
     }
 
     #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(py: Python) -> PyResult<PyObject> {
         let dict = pyo3::types::PyDict::new(py);
         for variant in [
             SensorType::Camera,
@@ -346,7 +348,8 @@ impl SensorType {
 #[pymethods]
 impl ImageEncoding {
     #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
+    #[pyo3(name = "from_str")]
+    pub fn py_from_str(s: &str) -> PyResult<Self> {
         s.parse()
             .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid ImageEncoding"))
     }
@@ -360,7 +363,8 @@ impl ImageEncoding {
     }
 
     #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(py: Python) -> PyResult<PyObject> {
         let dict = pyo3::types::PyDict::new(py);
         for variant in [
             ImageEncoding::RGB8,
@@ -463,9 +467,10 @@ impl Image {
         self.compress().map_err(PyRuntimeError::new_err)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("camera_info", self.camera_info.to_dict(py)?)?;
+        dict.set_item("camera_info", self.camera_info.py_to_dict(py)?)?;
         dict.set_item("height", self.height)?;
         dict.set_item("width", self.width)?;
         dict.set_item(
@@ -521,7 +526,8 @@ impl CompressedImage {
         self.decompress().map_err(PyRuntimeError::new_err)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item(
             "format",
@@ -556,7 +562,8 @@ impl CameraInfo {
         Self::new(width, height, distortion_model, d, k, r, p)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("width", self.width)?;
         dict.set_item("height", self.height)?;
@@ -578,9 +585,10 @@ impl ADSB {
         Self::new(message)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        let _ = dict.set_item("message", self.message.to_dict(py)?);
+        let _ = dict.set_item("message", self.message.py_to_dict(py)?);
         Ok(dict.into())
     }
 }
@@ -600,12 +608,13 @@ impl GNSS {
         Self::new(latitude, longitude, altitude, velocity, heading)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("latitude", self.latitude)?;
         dict.set_item("longitude", self.longitude)?;
         dict.set_item("altitude", self.altitude)?;
-        dict.set_item("velocity", self.velocity.to_dict(py)?)?;
+        dict.set_item("velocity", self.velocity.py_to_dict(py)?)?;
         dict.set_item("heading", self.heading)?;
         Ok(dict.into())
     }
@@ -620,11 +629,12 @@ impl IMU {
         Self::new(acceleration, gyroscope, magnetic_field)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("acceleration", self.acceleration.to_dict(py)?)?;
-        dict.set_item("gyroscope", self.gyroscope.to_dict(py)?)?;
-        dict.set_item("magnetic_field", self.magnetic_field.to_dict(py)?)?;
+        dict.set_item("acceleration", self.acceleration.py_to_dict(py)?)?;
+        dict.set_item("gyroscope", self.gyroscope.py_to_dict(py)?)?;
+        dict.set_item("magnetic_field", self.magnetic_field.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 }

--- a/aerosim-data/src/types/timestamp.rs
+++ b/aerosim-data/src/types/timestamp.rs
@@ -1,17 +1,20 @@
-use crate::types::PyTypeSupport;
 use crate::AerosimMessage;
 
 use chrono::{DateTime, Utc};
-use std::time::Duration;
-
-use pyo3::{
-    prelude::*,
-    types::{PyCapsule, PyDict},
-};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
-#[pyclass(get_all)]
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
+
+#[cfg_attr(feature = "python", pyclass(get_all))]
 #[derive(
     Clone,
     Copy,
@@ -31,14 +34,12 @@ pub struct TimeStamp {
     pub nanosec: u32,
 }
 
-#[pymethods]
+// Base Rust implementation
 impl TimeStamp {
-    #[new]
     pub fn new(sec: i32, nanosec: u32) -> Self {
         TimeStamp { sec, nanosec }
     }
 
-    #[staticmethod]
     pub fn from_sec(sec: f64) -> Self {
         TimeStamp {
             sec: sec.trunc() as i32,
@@ -56,7 +57,6 @@ impl TimeStamp {
         (raw_sec * multiplier).round() / multiplier
     }
 
-    #[staticmethod]
     pub fn from_millis(millisec: u64) -> Self {
         let dur = Duration::from_millis(millisec);
         TimeStamp {
@@ -69,7 +69,6 @@ impl TimeStamp {
         self.sec as u64 * 1e3 as u64 + self.nanosec as u64 / 1e6 as u64
     }
 
-    #[staticmethod]
     pub fn from_nanos(nanosec: u64) -> Self {
         let dur = Duration::from_nanos(nanosec);
         TimeStamp {
@@ -83,13 +82,66 @@ impl TimeStamp {
     }
 
     // Create a new TimeStamp from current time
-    #[staticmethod]
     pub fn now() -> Self {
         let now: DateTime<Utc> = Utc::now();
         TimeStamp {
             sec: now.timestamp() as i32,           // Seconds since epoch
             nanosec: now.timestamp_subsec_nanos(), // Nanoseconds since last second
         }
+    }
+}
+
+// Python interface layer
+#[cfg(feature = "python")]
+#[pymethods]
+impl TimeStamp {
+    #[new]
+    fn py_new(sec: i32, nanosec: u32) -> Self {
+        Self::new(sec, nanosec)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_sec")]
+    fn py_from_sec(sec: f64) -> Self {
+        Self::from_sec(sec)
+    }
+
+    #[pyo3(name = "to_sec")]
+    fn py_to_sec(&self) -> f64 {
+        self.to_sec()
+    }
+
+    #[pyo3(name = "to_sec_rounded")]
+    fn py_to_sec_rounded(&self, round_num_digits: u32) -> f64 {
+        self.to_sec_rounded(round_num_digits)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_millis")]
+    fn py_from_millis(millisec: u64) -> Self {
+        Self::from_millis(millisec)
+    }
+
+    #[pyo3(name = "to_millis")]
+    fn py_to_millis(&self) -> u64 {
+        self.to_millis()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_nanos")]
+    fn py_from_nanos(nanosec: u64) -> Self {
+        Self::from_nanos(nanosec)
+    }
+
+    #[pyo3(name = "to_nanos")]
+    fn py_to_nanos(&self) -> u64 {
+        self.to_nanos()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "now")]
+    fn py_now() -> Self {
+        Self::now()
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/timestamp.rs
+++ b/aerosim-data/src/types/timestamp.rs
@@ -144,7 +144,8 @@ impl TimeStamp {
         Self::now()
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("sec", self.sec)?;
         dict.set_item("nanosec", self.nanosec)?;

--- a/aerosim-data/src/types/trajectory.rs
+++ b/aerosim-data/src/types/trajectory.rs
@@ -1,11 +1,16 @@
-use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::AerosimMessage;
 
-use super::PyTypeSupport;
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
 
 // ----------------------------------------------------------------------------
 // Aircraft Trajectory Visualization Command
@@ -14,19 +19,14 @@ use super::PyTypeSupport;
 #[derive(
     Debug, Clone, Serialize, Deserialize, aerosim_macros::AerosimMessage, JsonSchema, Default,
 )]
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct TrajectoryVisualization {
     pub settings: TrajectoryVisualizationSettings,
     pub user_defined_waypoints: TrajectoryWaypoints,
     pub future_trajectory: TrajectoryWaypoints,
 }
 
-#[pymethods]
 impl TrajectoryVisualization {
-    #[new]
-    #[pyo3(signature = (settings = TrajectoryVisualizationSettings::default(),
-    user_defined_waypoints = None,
-    future_trajectory = None))]
     pub fn new(
         settings: TrajectoryVisualizationSettings,
         user_defined_waypoints: Option<TrajectoryWaypoints>,
@@ -39,6 +39,22 @@ impl TrajectoryVisualization {
             user_defined_waypoints,
             future_trajectory,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl TrajectoryVisualization {
+    #[new]
+    #[pyo3(signature = (settings = TrajectoryVisualizationSettings::default(),
+    user_defined_waypoints = None,
+    future_trajectory = None))]
+    fn py_new(
+        settings: TrajectoryVisualizationSettings,
+        user_defined_waypoints: Option<TrajectoryWaypoints>,
+        future_trajectory: Option<TrajectoryWaypoints>,
+    ) -> Self {
+        Self::new(settings, user_defined_waypoints, future_trajectory)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -59,7 +75,7 @@ impl TrajectoryVisualization {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, aerosim_macros::AerosimMessage, JsonSchema)]
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct TrajectoryVisualizationSettings {
     pub display_future_trajectory: bool,
     pub display_past_trajectory: bool,
@@ -78,15 +94,7 @@ impl Default for TrajectoryVisualizationSettings {
     }
 }
 
-#[pymethods]
 impl TrajectoryVisualizationSettings {
-    #[new]
-    #[pyo3(signature = (
-        display_future_trajectory=TrajectoryVisualizationSettings::default().display_future_trajectory,
-        display_past_trajectory=TrajectoryVisualizationSettings::default().display_past_trajectory,
-        highlight_user_defined_waypoints=TrajectoryVisualizationSettings::default().highlight_user_defined_waypoints,
-        number_of_future_waypoints=TrajectoryVisualizationSettings::default().number_of_future_waypoints
-    ))]
     pub fn new(
         display_future_trajectory: bool,
         display_past_trajectory: bool,
@@ -99,6 +107,31 @@ impl TrajectoryVisualizationSettings {
             highlight_user_defined_waypoints,
             number_of_future_waypoints,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl TrajectoryVisualizationSettings {
+    #[new]
+    #[pyo3(signature = (
+        display_future_trajectory=TrajectoryVisualizationSettings::default().display_future_trajectory,
+        display_past_trajectory=TrajectoryVisualizationSettings::default().display_past_trajectory,
+        highlight_user_defined_waypoints=TrajectoryVisualizationSettings::default().highlight_user_defined_waypoints,
+        number_of_future_waypoints=TrajectoryVisualizationSettings::default().number_of_future_waypoints
+    ))]
+    fn py_new(
+        display_future_trajectory: bool,
+        display_past_trajectory: bool,
+        highlight_user_defined_waypoints: bool,
+        number_of_future_waypoints: u64,
+    ) -> Self {
+        Self::new(
+            display_future_trajectory,
+            display_past_trajectory,
+            highlight_user_defined_waypoints,
+            number_of_future_waypoints,
+        )
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
@@ -125,17 +158,24 @@ impl TrajectoryVisualizationSettings {
 #[derive(
     Debug, Clone, Serialize, Deserialize, aerosim_macros::AerosimMessage, JsonSchema, Default,
 )]
-#[pyclass(get_all, set_all)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
 pub struct TrajectoryWaypoints {
     pub waypoints: String,
 }
 
+impl TrajectoryWaypoints {
+    pub fn new(waypoints: String) -> Self {
+        Self { waypoints }
+    }
+}
+
+#[cfg(feature = "python")]
 #[pymethods]
 impl TrajectoryWaypoints {
     #[new]
     #[pyo3(signature = (waypoints="".to_string()))]
-    pub fn new(waypoints: String) -> Self {
-        Self { waypoints }
+    fn py_new(waypoints: String) -> Self {
+        Self::new(waypoints)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/trajectory.rs
+++ b/aerosim-data/src/types/trajectory.rs
@@ -42,38 +42,6 @@ impl TrajectoryVisualization {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
-impl TrajectoryVisualization {
-    #[new]
-    #[pyo3(signature = (settings = TrajectoryVisualizationSettings::default(),
-    user_defined_waypoints = None,
-    future_trajectory = None))]
-    fn py_new(
-        settings: TrajectoryVisualizationSettings,
-        user_defined_waypoints: Option<TrajectoryWaypoints>,
-        future_trajectory: Option<TrajectoryWaypoints>,
-    ) -> Self {
-        Self::new(settings, user_defined_waypoints, future_trajectory)
-    }
-
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        dict.set_item("settings", self.settings.to_dict(py)?)?;
-        dict.set_item(
-            "user_defined_waypoints",
-            self.user_defined_waypoints.to_dict(py)?,
-        )?;
-        dict.set_item("future_trajectory", self.future_trajectory.to_dict(py)?)?;
-        Ok(dict.into())
-    }
-
-    #[classattr]
-    fn __type_support__() -> Py<PyCapsule> {
-        PyTypeSupport::create::<Self>()
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, aerosim_macros::AerosimMessage, JsonSchema)]
 #[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct TrajectoryVisualizationSettings {
@@ -107,6 +75,54 @@ impl TrajectoryVisualizationSettings {
             highlight_user_defined_waypoints,
             number_of_future_waypoints,
         }
+    }
+}
+
+#[derive(
+    Debug, Clone, Serialize, Deserialize, aerosim_macros::AerosimMessage, JsonSchema, Default,
+)]
+#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
+pub struct TrajectoryWaypoints {
+    pub waypoints: String,
+}
+
+impl TrajectoryWaypoints {
+    pub fn new(waypoints: String) -> Self {
+        Self { waypoints }
+    }
+}
+
+// Python interface layer
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl TrajectoryVisualization {
+    #[new]
+    #[pyo3(signature = (settings = TrajectoryVisualizationSettings::default(),
+    user_defined_waypoints = None,
+    future_trajectory = None))]
+    fn py_new(
+        settings: TrajectoryVisualizationSettings,
+        user_defined_waypoints: Option<TrajectoryWaypoints>,
+        future_trajectory: Option<TrajectoryWaypoints>,
+    ) -> Self {
+        Self::new(settings, user_defined_waypoints, future_trajectory)
+    }
+
+    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+        let dict = PyDict::new(py);
+        dict.set_item("settings", self.settings.to_dict(py)?)?;
+        dict.set_item(
+            "user_defined_waypoints",
+            self.user_defined_waypoints.to_dict(py)?,
+        )?;
+        dict.set_item("future_trajectory", self.future_trajectory.to_dict(py)?)?;
+        Ok(dict.into())
+    }
+
+    #[classattr]
+    fn __type_support__() -> Py<PyCapsule> {
+        PyTypeSupport::create::<Self>()
     }
 }
 
@@ -152,20 +168,6 @@ impl TrajectoryVisualizationSettings {
     #[classattr]
     fn __type_support__() -> Py<PyCapsule> {
         PyTypeSupport::create::<Self>()
-    }
-}
-
-#[derive(
-    Debug, Clone, Serialize, Deserialize, aerosim_macros::AerosimMessage, JsonSchema, Default,
-)]
-#[cfg_attr(feature = "python", pyclass(get_all, set_all))]
-pub struct TrajectoryWaypoints {
-    pub waypoints: String,
-}
-
-impl TrajectoryWaypoints {
-    pub fn new(waypoints: String) -> Self {
-        Self { waypoints }
     }
 }
 

--- a/aerosim-data/src/types/trajectory.rs
+++ b/aerosim-data/src/types/trajectory.rs
@@ -109,14 +109,15 @@ impl TrajectoryVisualization {
         Self::new(settings, user_defined_waypoints, future_trajectory)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("settings", self.settings.to_dict(py)?)?;
+        dict.set_item("settings", self.settings.py_to_dict(py)?)?;
         dict.set_item(
             "user_defined_waypoints",
-            self.user_defined_waypoints.to_dict(py)?,
+            self.user_defined_waypoints.py_to_dict(py)?,
         )?;
-        dict.set_item("future_trajectory", self.future_trajectory.to_dict(py)?)?;
+        dict.set_item("future_trajectory", self.future_trajectory.py_to_dict(py)?)?;
         Ok(dict.into())
     }
 
@@ -150,7 +151,8 @@ impl TrajectoryVisualizationSettings {
         )
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("display_future_trajectory", self.display_future_trajectory)?;
         dict.set_item("display_past_trajectory", self.display_past_trajectory)?;
@@ -180,7 +182,8 @@ impl TrajectoryWaypoints {
         Self::new(waypoints)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
         dict.set_item("waypoints", self.waypoints.clone())?;
         Ok(dict.into())

--- a/aerosim-data/src/types/typesupport/mod.rs
+++ b/aerosim-data/src/types/typesupport/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "python")]
 mod python_support;
 mod rust_support;
 
+#[cfg(feature = "python")]
 pub use python_support::PyTypeSupport;
 pub use rust_support::TypeSupport;

--- a/aerosim-data/src/types/vehicle.rs
+++ b/aerosim-data/src/types/vehicle.rs
@@ -1,22 +1,30 @@
-use crate::{types::PyTypeSupport, AerosimMessage};
+use crate::AerosimMessage;
 
 use super::actor::ActorState;
 use super::geometry::Vector3;
 
-use pyo3::prelude::*;
-use pyo3::types::{PyCapsule, PyDict};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 
+#[cfg(feature = "python")]
+use {
+    crate::types::PyTypeSupport,
+    pyo3::{
+        prelude::*,
+        types::{PyCapsule, PyDict},
+    },
+};
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, EnumString, Display, PartialEq)]
-#[pyclass(eq, eq_int)]
+#[cfg_attr(feature = "python", pyclass(eq, eq_int))]
 pub enum VehicleType {
     Ground,
     Aerial,
     Marine,
 }
 
+#[cfg(feature = "python")]
 #[pymethods]
 impl VehicleType {
     #[staticmethod]
@@ -48,7 +56,7 @@ impl VehicleType {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[pyclass(get_all)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
 pub struct VehicleState {
     pub state: ActorState,
     pub velocity: Vector3,
@@ -57,10 +65,7 @@ pub struct VehicleState {
     pub angular_acceleration: Vector3,
 }
 
-#[pymethods]
 impl VehicleState {
-    #[new]
-    #[pyo3(signature = (state=ActorState::default(), velocity=Vector3::default(), angular_velocity=Vector3::default(), acceleration=Vector3::default(), angular_acceleration=Vector3::default()))]
     pub fn new(
         state: ActorState,
         velocity: Vector3,
@@ -75,6 +80,22 @@ impl VehicleState {
             acceleration,
             angular_acceleration,
         }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl VehicleState {
+    #[new]
+    #[pyo3(signature = (state=ActorState::default(), velocity=Vector3::default(), angular_velocity=Vector3::default(), acceleration=Vector3::default(), angular_acceleration=Vector3::default()))]
+    fn py_new(
+        state: ActorState,
+        velocity: Vector3,
+        angular_velocity: Vector3,
+        acceleration: Vector3,
+        angular_acceleration: Vector3,
+    ) -> Self {
+        Self::new(state, velocity, angular_velocity, acceleration, angular_acceleration)
     }
 
     pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {

--- a/aerosim-data/src/types/vehicle.rs
+++ b/aerosim-data/src/types/vehicle.rs
@@ -58,7 +58,8 @@ impl VehicleState {
 #[pymethods]
 impl VehicleType {
     #[staticmethod]
-    pub fn from_str(s: &str) -> PyResult<Self> {
+    #[pyo3(name = "from_str")]
+    pub fn py_from_str(s: &str) -> PyResult<Self> {
         s.parse()
             .map_err(|_| PyErr::new::<pyo3::exceptions::PyValueError, _>("Invalid VehicleType"))
     }
@@ -72,7 +73,8 @@ impl VehicleType {
     }
 
     #[staticmethod]
-    pub fn to_dict(py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(py: Python) -> PyResult<PyObject> {
         let dict = pyo3::types::PyDict::new(py);
         for variant in [
             VehicleType::Ground,
@@ -100,15 +102,16 @@ impl VehicleState {
         Self::new(state, velocity, angular_velocity, acceleration, angular_acceleration)
     }
 
-    pub fn to_dict(&self, py: Python) -> PyResult<PyObject> {
+    #[pyo3(name = "to_dict")]
+    pub fn py_to_dict(&self, py: Python) -> PyResult<PyObject> {
         let dict = PyDict::new(py);
-        dict.set_item("state", self.state.to_dict(py)?)?;
-        dict.set_item("velocity", self.velocity.to_dict(py)?)?;
-        dict.set_item("angular_velocity", self.angular_velocity.to_dict(py)?)?;
-        dict.set_item("acceleration", self.acceleration.to_dict(py)?)?;
+        dict.set_item("state", self.state.py_to_dict(py)?)?;
+        dict.set_item("velocity", self.velocity.py_to_dict(py)?)?;
+        dict.set_item("angular_velocity", self.angular_velocity.py_to_dict(py)?)?;
+        dict.set_item("acceleration", self.acceleration.py_to_dict(py)?)?;
         dict.set_item(
             "angular_acceleration",
-            self.angular_acceleration.to_dict(py)?,
+            self.angular_acceleration.py_to_dict(py)?,
         )?;
         Ok(dict.into())
     }

--- a/aerosim-data/src/types/vehicle.rs
+++ b/aerosim-data/src/types/vehicle.rs
@@ -24,6 +24,36 @@ pub enum VehicleType {
     Marine,
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
+#[cfg_attr(feature = "python", pyclass(get_all))]
+pub struct VehicleState {
+    pub state: ActorState,
+    pub velocity: Vector3,
+    pub angular_velocity: Vector3,
+    pub acceleration: Vector3,
+    pub angular_acceleration: Vector3,
+}
+
+impl VehicleState {
+    pub fn new(
+        state: ActorState,
+        velocity: Vector3,
+        angular_velocity: Vector3,
+        acceleration: Vector3,
+        angular_acceleration: Vector3,
+    ) -> Self {
+        VehicleState {
+            state,
+            velocity,
+            angular_velocity,
+            acceleration,
+            angular_acceleration,
+        }
+    }
+}
+
+// Python interface layer
+
 #[cfg(feature = "python")]
 #[pymethods]
 impl VehicleType {
@@ -52,34 +82,6 @@ impl VehicleType {
             dict.set_item(variant.to_string(), variant.__repr__())?;
         }
         Ok(dict.into())
-    }
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, AerosimMessage, JsonSchema)]
-#[cfg_attr(feature = "python", pyclass(get_all))]
-pub struct VehicleState {
-    pub state: ActorState,
-    pub velocity: Vector3,
-    pub angular_velocity: Vector3,
-    pub acceleration: Vector3,
-    pub angular_acceleration: Vector3,
-}
-
-impl VehicleState {
-    pub fn new(
-        state: ActorState,
-        velocity: Vector3,
-        angular_velocity: Vector3,
-        acceleration: Vector3,
-        angular_acceleration: Vector3,
-    ) -> Self {
-        VehicleState {
-            state,
-            velocity,
-            angular_velocity,
-            acceleration,
-            angular_acceleration,
-        }
     }
 }
 

--- a/aerosim-scenarios/Cargo.toml
+++ b/aerosim-scenarios/Cargo.toml
@@ -11,7 +11,7 @@ name = "aerosim_scenarios"
 crate-type = ["cdylib"]
 
 [dependencies]
-aerosim-data = { path = "../aerosim-data", default-features = false }
+aerosim-data = { path = "../aerosim-data", default-features = false, features = ["python"] }
 pyo3.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/aerosim-sensors/Cargo.toml
+++ b/aerosim-sensors/Cargo.toml
@@ -11,7 +11,7 @@ name = "aerosim_sensors"
 crate-type = ["cdylib"]
 
 [dependencies]
-aerosim-data = { path = "../aerosim-data", default-features = false }
+aerosim-data = { path = "../aerosim-data", default-features = false, features = ["python"] }
 pyo3.workspace = true
 adsb_deku = "0.7.1"
 hex = "0.4.3"

--- a/aerosim-world-link/Cargo.lock
+++ b/aerosim-world-link/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "csv",
  "egm2008",
  "log",
- "pyo3",
  "quaternion-core",
  "serde",
  "serde_json",
@@ -46,8 +45,6 @@ dependencies = [
  "futures",
  "futures-util",
  "log",
- "pyo3",
- "pythonize",
  "rdkafka",
  "schemars 0.8.22",
  "serde",
@@ -1282,12 +1279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,15 +1536,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2007,12 +1989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,79 +2028,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "pyo3"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
-dependencies = [
- "cfg-if",
- "indoc",
- "libc",
- "memoffset",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
- "unindent",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
-dependencies = [
- "once_cell",
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "pythonize"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a6ee7a084f913f98d70cdc3ebec07e852b735ae3059a1500db2661265da9ff"
-dependencies = [
- "pyo3",
- "serde",
 ]
 
 [[package]]
@@ -3039,12 +2942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
 name = "tempfile"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,12 +3367,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-any-ors"

--- a/aerosim-world-link/Cargo.toml
+++ b/aerosim-world-link/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aerosim-core = { path = "../aerosim-core" }
-aerosim-data = { path = "../aerosim-data" }
+aerosim-core = { path = "../aerosim-core", default-features = false, features = [] }
+aerosim-data = { path = "../aerosim-data", default-features = false, features = ["kafka", "zenoh"] }
 futures = "0.3.31"
 lazy_static = "1.5.0"
 log = "0.4.25"


### PR DESCRIPTION
## Summary

- Make PyO3 an optional dependency behind a `python` Cargo feature flag in `aerosim-data` and `aerosim-core`, so `aerosim-world-link` (C FFI cdylib for Unreal/Omniverse) can depend on these crates without pulling in Python
- All `#[pyclass]`, `#[pymethods]`, `#[pyfunction]`, and `#[pymodule]` attributes are now conditionally compiled with `#[cfg(feature = "python")]` or `#[cfg_attr(feature = "python", ...)]`
- Python interface sections are grouped at the end of each file with a `// Python interface layer` comment
- All pymethods function definitions in `aerosim-data` use a `py_` prefix naming convention with `#[pyo3(name = "...")]` to preserve Python-facing names while avoiding collisions with Rust impl methods
- Downstream crates (`aerosim-scenarios`, `aerosim-sensors`, `aerosim-world`) propagate the `python` feature via `features = ["python"]` in their `Cargo.toml`
- `aerosim-world-link` depends on `aerosim-data` with `default-features = false` (no `python` feature), removing its transitive PyO3/Python dependency

## Changes

### aerosim-data
- `Cargo.toml`: `pyo3` moved to optional dependency, new `python` feature flag (enabled by default for backward compatibility)
- All type files (`types/*.rs`, `types/adsb/*.rs`, `types/downlink_format/*.rs`): `#[pyclass]` → `#[cfg_attr(feature = "python", pyclass)]`, pymethods blocks wrapped in `#[cfg(feature = "python")]`
- All middleware files (`middleware/*.rs`): Same conditional compilation pattern
- `lib.rs`: `#[pymodule]` wrapped in `#[cfg(feature = "python")]`

### aerosim-core
- `Cargo.toml`: `pyo3` moved to optional dependency, new `python` feature that also enables `aerosim-data/python`
- All source files: Same conditional compilation and grouping pattern as aerosim-data

### aerosim-world-link
- `Cargo.toml`: `aerosim-data` dependency changed to `default-features = false` with only `kafka` and `zenoh` features (no `python`)
- `Cargo.lock`: Removed `pyo3` and related transitive dependencies

### Downstream crates
- `aerosim-scenarios/Cargo.toml`, `aerosim-sensors/Cargo.toml`: Added explicit `features = ["python"]` for `aerosim-data` dependency

## Test plan

- [x] `cargo check` passes
- [x] `cargo test tests -p aerosim-data -p aerosim-core` — 36 tests pass
- [x] `./build_aerosim.sh` full build succeeds (maturin + world-link + uv sync)
- [x] Run example scenarios to verify Python bindings work end-to-end
- [x] Build aerosim-world-link on Windows to verify Python is no longer linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
