### PR TITLE
Improve error handling in Zenoh middleware and world-link message handler

### DIFF
--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -126,7 +126,12 @@ impl MiddlewareRaw for ZenohMiddleware {
             })
             .await;
 
-        let subscriber = session.declare_subscriber(topic).await.unwrap();
+        let subscriber = session
+            .declare_subscriber(topic)
+            .await
+            .map_err(|e| -> Box<dyn Error> {
+                format!("Failed to subscribe to topic '{}': {}", topic, e).into()
+            })?;
 
         let handle = tokio::task::spawn(async move {
             while let Ok(sample) = subscriber.recv_async().await {
@@ -157,7 +162,13 @@ impl MiddlewareRaw for ZenohMiddleware {
         let callback_arc = Arc::new(callback);
 
         for (_message_type, topic) in topics {
-            let subscriber = session.declare_subscriber(&topic).await.unwrap();
+            let subscriber = match session.declare_subscriber(&topic).await {
+                Ok(sub) => sub,
+                Err(e) => {
+                    log::error!("Failed to subscribe to topic '{}': {}", topic, e);
+                    continue;
+                }
+            };
             let callback_clone = Arc::clone(&callback_arc);
             let handle = tokio::task::spawn(async move {
                 while let Ok(sample) = subscriber.recv_async().await {

--- a/aerosim-world-link/src/message_handler.rs
+++ b/aerosim-world-link/src/message_handler.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::vec;
 use std::{cmp::Ordering, collections::BinaryHeap};
 
-use log::{info, warn};
+use log::{error, info, warn};
 use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -220,9 +220,12 @@ impl MessageHandler {
             .take()
             .expect("No message thread handle, was it started?");
 
-        handle
-            .join()
-            .expect("Thread should have stopped after receiving stop flag.");
+        if let Err(e) = handle.join() {
+            error!(
+                "[aerosim.renderer.message_handler] Message thread panicked during shutdown: {:?}",
+                e
+            );
+        }
 
         self.transport.shutdown();
 


### PR DESCRIPTION
## Summary

- Replace `.unwrap()` calls on Zenoh `declare_subscriber` with proper error handling: propagate errors via `?` in `subscribe_raw` and gracefully skip failed subscriptions with `continue` in `subscribe_all_raw`
- Replace `.expect()` on message thread `join()` in `aerosim-world-link` `MessageHandler::stop()` with error logging, preventing the main thread from panicking if the message thread panicked during shutdown

## Test plan

- [x] Run a simulation with Zenoh transport to verify publish/subscribe still works end-to-end
- [x] Verify graceful shutdown behavior when stopping a renderer connected via world-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
