### PR TITLE
Add dot-to-slash key translation in Zenoh middleware for wildcard support

### DIFF
--- a/aerosim-data/src/middleware/zenoh.rs
+++ b/aerosim-data/src/middleware/zenoh.rs
@@ -11,6 +11,16 @@ use crate::middleware::{
     CallbackClosureRaw, Middleware, MiddlewareRaw, Serializer, SerializerEnum,
 };
 
+/// Convert a dot-separated topic to a slash-separated Zenoh key expression.
+/// This allows Zenoh wildcard matching (e.g. `aerosim/**`) to work correctly,
+/// since Zenoh uses `/` as the key expression separator.
+/// Kafka topics use `.` which is incompatible with `/`, so the translation
+/// is done at the Zenoh middleware boundary to keep the rest of the codebase
+/// using a single dot-separated topic format.
+fn topic_to_zenoh_key(topic: &str) -> String {
+    topic.replace('.', "/")
+}
+
 #[cfg(feature = "python")]
 use {
     crate::middleware::{Metadata, PyMiddleware, PySerializer},
@@ -100,8 +110,9 @@ impl MiddlewareRaw for ZenohMiddleware {
             })
             .await;
 
+        let key = topic_to_zenoh_key(topic);
         session
-            .put(topic, payload)
+            .put(&key, payload)
             .congestion_control(zenoh::qos::CongestionControl::Block)
             .await
             .map_err(|e| -> Box<dyn Error> {
@@ -126,11 +137,12 @@ impl MiddlewareRaw for ZenohMiddleware {
             })
             .await;
 
+        let key = topic_to_zenoh_key(topic);
         let subscriber = session
-            .declare_subscriber(topic)
+            .declare_subscriber(&key)
             .await
             .map_err(|e| -> Box<dyn Error> {
-                format!("Failed to subscribe to topic '{}': {}", topic, e).into()
+                format!("Failed to subscribe to topic '{}' (key '{}'): {}", topic, key, e).into()
             })?;
 
         let handle = tokio::task::spawn(async move {
@@ -162,10 +174,11 @@ impl MiddlewareRaw for ZenohMiddleware {
         let callback_arc = Arc::new(callback);
 
         for (_message_type, topic) in topics {
-            let subscriber = match session.declare_subscriber(&topic).await {
+            let key = topic_to_zenoh_key(&topic);
+            let subscriber = match session.declare_subscriber(&key).await {
                 Ok(sub) => sub,
                 Err(e) => {
-                    log::error!("Failed to subscribe to topic '{}': {}", topic, e);
+                    log::error!("Failed to subscribe to topic '{}' (key '{}'): {}", topic, key, e);
                     continue;
                 }
             };
@@ -413,6 +426,15 @@ mod tests {
         id: u32,
         name: String,
         value: f64,
+    }
+
+    #[test]
+    fn test_topic_to_zenoh_key() {
+        assert_eq!(topic_to_zenoh_key("aerosim.clock.tick_group_01"), "aerosim/clock/tick_group_01");
+        assert_eq!(topic_to_zenoh_key("aerosim.actor1.vehicle_state"), "aerosim/actor1/vehicle_state");
+        assert_eq!(topic_to_zenoh_key("aerosim.**"), "aerosim/**");
+        assert_eq!(topic_to_zenoh_key("aerosim.*.vehicle_state"), "aerosim/*/vehicle_state");
+        assert_eq!(topic_to_zenoh_key("no_dots"), "no_dots");
     }
 
     #[test]

--- a/aerosim-world-link/src/message_handler.rs
+++ b/aerosim-world-link/src/message_handler.rs
@@ -762,9 +762,11 @@ fn handle_raw_topic_message(
     let timestamp_sim_f64: f64 =
         metadata.timestamp_sim.sec as f64 + metadata.timestamp_sim.nanosec as f64 / 1_000_000_000.0;
 
-    // Wrap the data with topic and type metadata so the consumer can distinguish messages
+    // Wrap the data with topic and type metadata so the consumer can distinguish messages.
+    // Use metadata.topic (the actual published topic) rather than the subscription key
+    // expression, which may be a wildcard pattern like "aerosim.**".
     let envelope = json!({
-        "topic": topic,
+        "topic": metadata.topic,
         "message_type": metadata.type_name,
         "timestamp_sim": {
             "sec": metadata.timestamp_sim.sec,


### PR DESCRIPTION
## Summary

- Add `topic_to_zenoh_key()` translation at the Zenoh middleware boundary that converts dot-separated topics (e.g. `aerosim.clock.tick_group_01`) to slash-separated Zenoh key expressions (e.g. `aerosim/clock/tick_group_01`), enabling Zenoh wildcard subscriptions (`*`, `**`) to work correctly
- Kafka requires `.` separators and does not allow `/` in topic names, so the translation is done only in the Zenoh layer to keep a single dot-separated topic format across the rest of the codebase
- Update `aerosim-world-link` message handler to use `metadata.topic` for the envelope topic field instead of the subscription key expression, which would otherwise pass through wildcard patterns like `aerosim.**` as the topic name

## Test plan

- [x] `cargo test -p aerosim-data tests --verbose` — all 38 tests pass including new `test_topic_to_zenoh_key`
- [x] Run simulation with Zenoh transport to verify publish/subscribe works end-to-end with translated keys
- [x] Test wildcard subscription (e.g. `aerosim.**`) receives messages from all matching topics
- [x] Verify world-link envelope contains the actual topic name, not the wildcard pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
